### PR TITLE
Usuário cadastra categorias de trabalho (com comentários) em seu perfil

### DIFF
--- a/app/controllers/profile_job_categories_controller.rb
+++ b/app/controllers/profile_job_categories_controller.rb
@@ -1,0 +1,17 @@
+class ProfileJobCategoriesController < ApplicationController
+  def new
+    @profile_job_category = current_user.profile.profile_job_categories.build
+  end
+
+  def create
+    @profile_job_category = current_user.profile.profile_job_categories.build(profile_job_category_params)
+    @profile_job_category.save!
+    redirect_to user_profile_path, notice: 'Categoria de trabalho adicionada com sucesso!'
+  end
+
+  private
+
+  def profile_job_category_params
+    params.require(:profile_job_category).permit(:job_category_id, :description)
+  end
+end

--- a/app/controllers/profile_job_categories_controller.rb
+++ b/app/controllers/profile_job_categories_controller.rb
@@ -4,7 +4,7 @@ class ProfileJobCategoriesController < ApplicationController
 
   def new
     @profile_job_category = current_user.profile.profile_job_categories.build
-    flash[:notice] = t('.inform_user_edit_is_unavaiable')
+    flash[:notice] = t('.inform_user_edit_is_unavailable')
   end
 
   def create

--- a/app/controllers/profile_job_categories_controller.rb
+++ b/app/controllers/profile_job_categories_controller.rb
@@ -1,12 +1,19 @@
 class ProfileJobCategoriesController < ApplicationController
+  before_action :authenticate_user!, only: %w[new create]
+
   def new
     @profile_job_category = current_user.profile.profile_job_categories.build
   end
 
   def create
     @profile_job_category = current_user.profile.profile_job_categories.build(profile_job_category_params)
-    @profile_job_category.save!
-    redirect_to user_profile_path, notice: 'Categoria de trabalho adicionada com sucesso!'
+
+    if @profile_job_category.save
+      redirect_to user_profile_path, notice: t('.success')
+    else
+      flash.now[:alert] = t('.error')
+      render :new, status: :unprocessable_entity
+    end
   end
 
   private

--- a/app/controllers/profile_job_categories_controller.rb
+++ b/app/controllers/profile_job_categories_controller.rb
@@ -1,8 +1,10 @@
 class ProfileJobCategoriesController < ApplicationController
   before_action :authenticate_user!, only: %w[new create]
+  before_action :check_if_job_categories_exist, only: %w[new create]
 
   def new
     @profile_job_category = current_user.profile.profile_job_categories.build
+    flash[:notice] = t('.inform_user_edit_is_unavaiable')
   end
 
   def create
@@ -20,5 +22,9 @@ class ProfileJobCategoriesController < ApplicationController
 
   def profile_job_category_params
     params.require(:profile_job_category).permit(:job_category_id, :description)
+  end
+
+  def check_if_job_categories_exist
+    redirect_to user_profile_path, notice: t('.check_if_job_categories_exist.error') if JobCategory.none?
   end
 end

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -1,6 +1,7 @@
 class Profile < ApplicationRecord
   belongs_to :user
   has_one :personal_info, dependent: :destroy
+  has_many :profile_job_categories, dependent: :destroy
 
   accepts_nested_attributes_for :personal_info
 

--- a/app/models/profile_job_category.rb
+++ b/app/models/profile_job_category.rb
@@ -1,4 +1,6 @@
 class ProfileJobCategory < ApplicationRecord
   belongs_to :profile
   belongs_to :job_category
+
+  validates :job_category, presence: true
 end

--- a/app/models/profile_job_category.rb
+++ b/app/models/profile_job_category.rb
@@ -2,5 +2,5 @@ class ProfileJobCategory < ApplicationRecord
   belongs_to :profile
   belongs_to :job_category
 
-  validates :job_category, presence: true
+  validates :job_category_id, presence: true
 end

--- a/app/models/profile_job_category.rb
+++ b/app/models/profile_job_category.rb
@@ -3,4 +3,5 @@ class ProfileJobCategory < ApplicationRecord
   belongs_to :job_category
 
   validates :job_category_id, presence: true
+  validates :job_category_id, uniqueness: { scope: :profile_id }
 end

--- a/app/views/profile/show.html.erb
+++ b/app/views/profile/show.html.erb
@@ -18,15 +18,15 @@
   </ul>
 </div>
 <div id='profile-job-categories'>
-  <h3>Categorias de Trabalho</h3>
-  <%= link_to 'Adicionar nova categoria de trabalho', new_profile_job_category_path %>
-  <div>
+  <h3><%= t('content.section_title') %></h3>
+  <%= link_to t('links.new_profile_job_category_path'), new_profile_job_category_path, class:'btn btn-primary' %>
+  <div class='mt-2'>
     <% @profile.profile_job_categories.each do |profile_job_category| %>
       <p><strong><%= profile_job_category.job_category.name %></strong></p>
       <% if profile_job_category.description.present? %>
         <p><%= profile_job_category.description %></p>
       <% else %>
-        <p>Não foi adicionada uma descrição para essa categoria.</p>
+        <p><%= t('content.profile_job_category_without_description') %></p>
       <% end %>
     <% end %>
   </div>

--- a/app/views/profile/show.html.erb
+++ b/app/views/profile/show.html.erb
@@ -17,3 +17,17 @@
     <li>Visível: <%= t(@profile.user.personal_info.visibility) %></li>
   </ul>
 </div>
+<div id='profile-job-categories'>
+  <h3>Categorias de Trabalho</h3>
+  <%= link_to 'Adicionar nova categoria de trabalho', new_profile_job_category_path %>
+  <div>
+    <% @profile.profile_job_categories.each do |profile_job_category| %>
+      <p><strong><%= profile_job_category.job_category.name %></strong></p>
+      <% if profile_job_category.description.present? %>
+        <p><%= profile_job_category.description %></p>
+      <% else %>
+        <p>Não foi adicionada uma descrição para essa categoria.</p>
+      <% end %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/profile_job_categories/new.html.erb
+++ b/app/views/profile_job_categories/new.html.erb
@@ -1,7 +1,9 @@
 <h1><%= t('content.new_form_title') %></h1>
 <% if @profile_job_category.errors.any? %>
   <% @profile_job_category.errors.full_messages.each do |msg| %>
-    <%= msg %>
+    <p class="alert alert-warning">
+      <%= msg %>
+    </p>
   <% end %>
 <% end %>
 <%= form_with model: @profile_job_category do |f| %>

--- a/app/views/profile_job_categories/new.html.erb
+++ b/app/views/profile_job_categories/new.html.erb
@@ -8,11 +8,11 @@
 <% end %>
 <%= form_with model: @profile_job_category do |f| %>
   <div class="mb-3">
-    <%= f.label :job_category_id, class: 'form-laber' %>
+    <%= f.label :job_category_id, class: 'form-label' %>
     <%= f.collection_select :job_category_id, JobCategory.order(:name), :id, :name, {prompt: 'Selecione uma categoria'}, class: 'form-select' %>
   </div>
   <div class="mb-3">
-    <%= f.label :description, 'Descrição', class: 'form-laber' %>
+    <%= f.label :description, 'Descrição', class: 'form-label' %>
     <%= f.text_area :description, class: 'form-control' %>
   </div>
   <div class="mb-3">

--- a/app/views/profile_job_categories/new.html.erb
+++ b/app/views/profile_job_categories/new.html.erb
@@ -1,19 +1,20 @@
-<h1>Cadastrar Categoria de Trabalho no Perfil</h1>
+<h1><%= t('content.new_form_title') %></h1>
 <% if @profile_job_category.errors.any? %>
   <% @profile_job_category.errors.full_messages.each do |msg| %>
     <%= msg %>
   <% end %>
 <% end %>
 <%= form_with model: @profile_job_category do |f| %>
-  <div>
-    <%= f.label :job_category_id, 'Categoria' %>
-    <%=  f.collection_select :job_category_id, JobCategory.order(:name), :id, :name, prompt: 'Selecione uma categoria' %>
+  <div class="mb-3">
+    <%= f.label :job_category_id, class: 'form-laber' %>
+    <%= f.collection_select :job_category_id, JobCategory.order(:name), :id, :name, {prompt: 'Selecione uma categoria'}, class: 'form-select' %>
   </div>
-  <div>
-    <%= f.label :description, 'Descrição' %>
-    <%= f.text_area :description %>
+  <div class="mb-3">
+    <%= f.label :description, 'Descrição', class: 'form-laber' %>
+    <%= f.text_area :description, class: 'form-control' %>
   </div>
-  <div>
-    <%= f.submit 'Salvar' %>
+  <div class="mb-3">
+    <%= f.submit t('buttons.save'), class: 'btn btn-primary' %>
+    <%= link_to t('buttons.return'), user_profile_path, class: 'btn btn-secondary' %>
   </div>
 <% end %>

--- a/app/views/profile_job_categories/new.html.erb
+++ b/app/views/profile_job_categories/new.html.erb
@@ -1,4 +1,9 @@
 <h1>Cadastrar Categoria de Trabalho no Perfil</h1>
+<% if @profile_job_category.errors.any? %>
+  <% @profile_job_category.errors.full_messages.each do |msg| %>
+    <%= msg %>
+  <% end %>
+<% end %>
 <%= form_with model: @profile_job_category do |f| %>
   <div>
     <%= f.label :job_category_id, 'Categoria' %>

--- a/app/views/profile_job_categories/new.html.erb
+++ b/app/views/profile_job_categories/new.html.erb
@@ -1,0 +1,14 @@
+<h1>Cadastrar Categoria de Trabalho no Perfil</h1>
+<%= form_with model: @profile_job_category do |f| %>
+  <div>
+    <%= f.label :job_category_id, 'Categoria' %>
+    <%=  f.collection_select :job_category_id, JobCategory.order(:name), :id, :name, prompt: 'Selecione uma categoria' %>
+  </div>
+  <div>
+    <%= f.label :description, 'Descrição' %>
+    <%= f.text_area :description %>
+  </div>
+  <div>
+    <%= f.submit 'Salvar' %>
+  </div>
+<% end %>

--- a/config/locales/profile_job_category.pt-BR.yml
+++ b/config/locales/profile_job_category.pt-BR.yml
@@ -1,0 +1,14 @@
+pt-BR:
+  activerecord:
+    models:
+      profile_job_category: 
+        one: Categoria de trabalho
+        other: Categorias de trabalho
+    attributes:
+      profile_job_category:
+        job_category: Categoria de trabalho
+        description: Descrição
+  profile_job_categories:
+    create:
+      success: Categoria de trabalho adicionada com sucesso!
+      error: Não foi possível adicionar a categoria de trabalho.

--- a/config/locales/profile_job_category.pt-BR.yml
+++ b/config/locales/profile_job_category.pt-BR.yml
@@ -14,7 +14,7 @@ pt-BR:
       success: Categoria de trabalho adicionada com sucesso!
       error: Não foi possível adicionar a categoria de trabalho.
     new:
-      inform_user_edit_is_unavaiable: 'Atenção: Os dados cadastrados não poderão ser alterados após salvar. Preencha com cuidado.'
+      inform_user_edit_is_unavailable: 'Atenção: Os dados cadastrados não poderão ser alterados após salvar. Preencha com cuidado.'
       check_if_job_categories_exist:
         error: Essa página não está disponível no momento, entre em contato com o administrador.
   links:        

--- a/config/locales/profile_job_category.pt-BR.yml
+++ b/config/locales/profile_job_category.pt-BR.yml
@@ -7,8 +7,19 @@ pt-BR:
     attributes:
       profile_job_category:
         job_category: Categoria de trabalho
+        job_category_id: Categoria de trabalho
         description: Descrição
   profile_job_categories:
     create:
       success: Categoria de trabalho adicionada com sucesso!
       error: Não foi possível adicionar a categoria de trabalho.
+    new:
+      inform_user_edit_is_unavaiable: 'Atenção: Os dados cadastrados não poderão ser alterados após salvar. Preencha com cuidado.'
+      check_if_job_categories_exist:
+        error: Essa página não está disponível no momento, entre em contato com o administrador.
+  links:        
+    new_profile_job_category_path: Adicionar nova categoria de trabalho
+  content:
+    profile_job_category_without_description: Não foi adicionada uma descrição para essa categoria.
+    section_title: Categorias de Trabalho
+    new_form_title: Cadastrar Categoria de Trabalho no Perfil

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -228,4 +228,7 @@ pt-BR:
       long: "%d de %B de %Y, %H:%M"
       short: "%d de %B, %H:%M"
     pm: pm
+  buttons:
+    save: Salvar
+    return: Voltar
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,4 +17,5 @@ Rails.application.routes.draw do
 
   resources :job_categories, only: %i[index create]
   resource :profile, only: %i[edit update show], controller: :profile, as: :user_profile
+  resources :profile_job_categories, only: %i[new create]
 end

--- a/db/migrate/20240126130624_add_index_to_profile_job_categories.rb
+++ b/db/migrate/20240126130624_add_index_to_profile_job_categories.rb
@@ -1,0 +1,5 @@
+class AddIndexToProfileJobCategories < ActiveRecord::Migration[7.1]
+  def change
+    add_index :profile_job_categories, [:job_category_id, :profile_id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,30 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_01_22_134436) do
+ActiveRecord::Schema[7.1].define(version: 2024_01_24_133754) do
+  create_table "connections", force: :cascade do |t|
+    t.integer "follower_id", null: false
+    t.integer "followed_profile_id", null: false
+    t.integer "status", default: 1
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["followed_profile_id", "follower_id"], name: "index_connections_on_followed_profile_id_and_follower_id", unique: true
+    t.index ["followed_profile_id"], name: "index_connections_on_followed_profile_id"
+    t.index ["follower_id"], name: "index_connections_on_follower_id"
+  end
+
+  create_table "education_infos", force: :cascade do |t|
+    t.string "institution"
+    t.string "course"
+    t.date "start_date"
+    t.date "end_date"
+    t.boolean "visibility", default: true
+    t.integer "profile_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["profile_id"], name: "index_education_infos_on_profile_id"
+  end
+
   create_table "job_categories", force: :cascade do |t|
     t.string "name"
     t.datetime "created_at", null: false
@@ -43,6 +66,18 @@ ActiveRecord::Schema[7.1].define(version: 2024_01_22_134436) do
     t.index ["user_id"], name: "index_posts_on_user_id"
   end
 
+  create_table "professional_infos", force: :cascade do |t|
+    t.string "company"
+    t.string "position"
+    t.date "start_date"
+    t.date "end_date"
+    t.integer "profile_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.boolean "visibility"
+    t.index ["profile_id"], name: "index_professional_infos_on_profile_id"
+  end
+
   create_table "profile_job_categories", force: :cascade do |t|
     t.integer "profile_id", null: false
     t.integer "job_category_id", null: false
@@ -70,15 +105,19 @@ ActiveRecord::Schema[7.1].define(version: 2024_01_22_134436) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "full_name"
-    t.string "citizen_id_number"
     t.integer "role", default: 0
+    t.string "citizen_id_number"
     t.index ["citizen_id_number"], name: "index_users_on_citizen_id_number", unique: true
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "connections", "profiles", column: "followed_profile_id"
+  add_foreign_key "connections", "profiles", column: "follower_id"
+  add_foreign_key "education_infos", "profiles"
   add_foreign_key "personal_infos", "profiles"
   add_foreign_key "posts", "users"
+  add_foreign_key "professional_infos", "profiles"
   add_foreign_key "profile_job_categories", "job_categories"
   add_foreign_key "profile_job_categories", "profiles"
   add_foreign_key "profiles", "users"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_01_24_133754) do
+ActiveRecord::Schema[7.1].define(version: 2024_01_26_130624) do
   create_table "connections", force: :cascade do |t|
     t.integer "follower_id", null: false
     t.integer "followed_profile_id", null: false
@@ -84,6 +84,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_01_24_133754) do
     t.text "description"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["job_category_id", "profile_id"], name: "index_profile_job_categories_on_job_category_id_and_profile_id", unique: true
     t.index ["job_category_id"], name: "index_profile_job_categories_on_job_category_id"
     t.index ["profile_id"], name: "index_profile_job_categories_on_profile_id"
   end

--- a/spec/requests/user_create_profile_job_category_spec.rb
+++ b/spec/requests/user_create_profile_job_category_spec.rb
@@ -6,7 +6,7 @@ describe 'Usuário cadastra categoria de trabalho em seu perfil' do
     job_category = create(:job_category, name: 'Luta com espadas')
 
     login_as user
-    post profile_job_categories_path, params: { profile_job_category: { job_category_id: job_category.id, 
+    post profile_job_categories_path, params: { profile_job_category: { job_category_id: job_category.id,
                                                                         description: 'Sou um Jedi' } }
 
     expect(response).to redirect_to(user_profile_path)
@@ -19,9 +19,9 @@ describe 'Usuário cadastra categoria de trabalho em seu perfil' do
   it 'apenas quando autenticado' do
     job_category = create(:job_category, name: 'Luta com espadas')
 
-    post profile_job_categories_path, params: { profile_job_category: { job_category_id: job_category.id, 
+    post profile_job_categories_path, params: { profile_job_category: { job_category_id: job_category.id,
                                                                         description: 'Sou um Jedi' } }
-    
+
     expect(response).to redirect_to(new_user_session_path)
     expect(ProfileJobCategory.all).to be_empty
   end
@@ -32,7 +32,7 @@ describe 'Usuário cadastra categoria de trabalho em seu perfil' do
     job_category = create(:job_category)
 
     login_as hacker
-    post profile_job_categories_path, params: { profile_job_category: { job_category_id: job_category.id, 
+    post profile_job_categories_path, params: { profile_job_category: { job_category_id: job_category.id,
                                                                         description: 'Sou muito malvado',
                                                                         profile_id: user.id } }
 

--- a/spec/requests/user_create_profile_job_category_spec.rb
+++ b/spec/requests/user_create_profile_job_category_spec.rb
@@ -1,0 +1,41 @@
+require 'rails_helper'
+
+describe 'Usuário cadastra categoria de trabalho em seu perfil' do
+  it 'com sucesso' do
+    user = create(:user)
+    job_category = create(:job_category, name: 'Luta com espadas')
+
+    login_as user
+    post profile_job_categories_path, params: { profile_job_category: { job_category_id: job_category.id, 
+                                                                        description: 'Sou um Jedi' } }
+
+    expect(response).to redirect_to(user_profile_path)
+    expect(ProfileJobCategory.all).not_to be_empty
+    expect(ProfileJobCategory.first.profile).to eq user.profile
+    expect(ProfileJobCategory.first.job_category).to eq job_category
+    expect(ProfileJobCategory.first.description).to eq 'Sou um Jedi'
+  end
+
+  it 'apenas quando autenticado' do
+    job_category = create(:job_category, name: 'Luta com espadas')
+
+    post profile_job_categories_path, params: { profile_job_category: { job_category_id: job_category.id, 
+                                                                        description: 'Sou um Jedi' } }
+    
+    expect(response).to redirect_to(new_user_session_path)
+    expect(ProfileJobCategory.all).to be_empty
+  end
+
+  it 'apenas para sua própria conta' do
+    hacker = create(:user, email: 'hacker@vilao.com', citizen_id_number: '65315399095')
+    user = create(:user)
+    job_category = create(:job_category)
+
+    login_as hacker
+    post profile_job_categories_path, params: { profile_job_category: { job_category_id: job_category.id, 
+                                                                        description: 'Sou muito malvado',
+                                                                        profile_id: user.id } }
+
+    expect(user.profile.profile_job_categories).to be_empty
+  end
+end

--- a/spec/system/profile_job_categories/user_create_profile_job_category_spec.rb
+++ b/spec/system/profile_job_categories/user_create_profile_job_category_spec.rb
@@ -1,0 +1,50 @@
+require 'rails_helper'
+
+describe 'Usuário cadastra categoria de trabalho em seu perfil' do
+  it 'com sucesso' do
+    user = create(:user, full_name: 'Zelda Hyrule')
+    create(:job_category, name: 'Luta com espada')
+    create(:job_category, name: 'Magia')
+    create(:job_category, name: 'Gestão de Reino Feudal')
+
+    login_as user
+    visit root_path
+    click_on 'Zelda'
+    click_on 'Adicionar nova categoria de trabalho'
+
+    select 'Gestão de Reino Feudal', from: 'Categoria'
+    fill_in 'Descrição', with: 'Sou princesa vitalícia de um reino constantemente em guerra com o mal.'
+    click_on 'Salvar'
+
+    expect(user.profile.profile_job_categories).not_to be_empty
+    expect(page).to have_current_path user_profile_path
+    expect(page).to have_content 'Categoria de trabalho adicionada com sucesso!'
+    expect(page).to have_content 'Gestão de Reino Feudal'
+    expect(page).to have_content 'Sou princesa vitalícia de um reino constantemente em guerra com o mal.'
+    expect(page).not_to have_content 'Luta com espada'
+    expect(page).not_to have_content 'Magia'
+  end
+
+  it 'com sucesso, mesmo deixando a descrição em branco' do
+    user = create(:user, full_name: 'Zelda Hyrule')
+    create(:job_category, name: 'Magia')
+
+    login_as user
+    visit new_profile_job_category_path
+    select 'Magia', from: 'Categoria'
+    fill_in 'Descrição', with: ''
+    click_on 'Salvar'
+
+    expect(user.profile.profile_job_categories).not_to be_empty
+    expect(page).to have_content 'Categoria de trabalho adicionada com sucesso!'
+    expect(page).to have_content 'Magia'
+    expect(page).to have_content 'Não foi adicionada uma descrição para essa categoria.'
+  end
+
+  pending 'apenas quando autenticado'
+  pending 'e deve escolher uma categoria de trabalho existente'
+  pending 'mas é redirecionado se não existem categorias de trabalho disponíveis'
+  pending 'apenas se for o dono do perfil sendo alterado'
+  pending 'usuário é alertado na tela de formulário que não é possível editar os dados'
+  # pending '[request] tenta cadastrar uma categoria que não existe'
+end

--- a/spec/system/profile_job_categories/user_create_profile_job_category_spec.rb
+++ b/spec/system/profile_job_categories/user_create_profile_job_category_spec.rb
@@ -16,7 +16,7 @@ describe 'Usuário cadastra categoria de trabalho em seu perfil' do
     fill_in 'Descrição', with: 'Sou princesa vitalícia de um reino constantemente em guerra com o mal.'
     click_on 'Salvar'
 
-    expect(user.profile.profile_job_categories).not_to be_empty
+    expect(ProfileJobCategory.all).not_to be_empty
     expect(page).to have_current_path user_profile_path
     expect(page).to have_content 'Categoria de trabalho adicionada com sucesso!'
     expect(page).to have_content 'Gestão de Reino Feudal'
@@ -35,14 +35,36 @@ describe 'Usuário cadastra categoria de trabalho em seu perfil' do
     fill_in 'Descrição', with: ''
     click_on 'Salvar'
 
-    expect(user.profile.profile_job_categories).not_to be_empty
+    expect(ProfileJobCategory.all).not_to be_empty
     expect(page).to have_content 'Categoria de trabalho adicionada com sucesso!'
     expect(page).to have_content 'Magia'
     expect(page).to have_content 'Não foi adicionada uma descrição para essa categoria.'
   end
 
-  pending 'apenas quando autenticado'
-  pending 'e deve escolher uma categoria de trabalho existente'
+  it 'apenas quando autenticado' do
+    visit new_profile_job_category_path
+
+    expect(page).to have_current_path new_user_session_path
+  end
+
+  it 'e deve escolher uma categoria de trabalho existente' do
+    user = create(:user)
+    create(:job_category, name: 'Desenvolvimento de Jogos')
+
+    login_as user
+    visit new_profile_job_category_path
+    select 'Selecione uma categoria', from: 'Categoria'
+    fill_in 'Descrição', with: 'Preguiça de escolher categoria...'
+    click_on 'Salvar'
+
+    expect(ProfileJobCategory.all).to be_empty
+    expect(page).to have_content 'Cadastrar Categoria de Trabalho no Perfil'
+    expect(page).to have_field 'Descrição', with: 'Preguiça de escolher categoria...'
+    expect(page).to have_content 'Não foi possível adicionar a categoria de trabalho.'
+    expect(page).to have_content 'Categoria de trabalho é obrigatório(a)'
+    expect(page).to have_content 'Categoria de trabalho não pode ficar em branco'
+  end
+
   pending 'mas é redirecionado se não existem categorias de trabalho disponíveis'
   pending 'apenas se for o dono do perfil sendo alterado'
   pending 'usuário é alertado na tela de formulário que não é possível editar os dados'

--- a/spec/system/profile_job_categories/user_create_profile_job_category_spec.rb
+++ b/spec/system/profile_job_categories/user_create_profile_job_category_spec.rb
@@ -65,8 +65,34 @@ describe 'Usuário cadastra categoria de trabalho em seu perfil' do
     expect(page).to have_content 'Categoria de trabalho não pode ficar em branco'
   end
 
-  pending 'mas é redirecionado se não existem categorias de trabalho disponíveis'
-  pending 'apenas se for o dono do perfil sendo alterado'
-  pending 'usuário é alertado na tela de formulário que não é possível editar os dados'
-  # pending '[request] tenta cadastrar uma categoria que não existe'
+  it 'mas é redirecionado se não existem categorias de trabalho disponíveis' do
+    user = create(:user)
+
+    login_as user
+    visit new_profile_job_category_path
+
+    expect(page).to have_content 'Essa página não está disponível no momento, entre em contato com o administrador.'
+    expect(page).to have_current_path user_profile_path
+  end
+
+  it 'e é alertado no formulário sobre não poder editar ou remover os dados no futuro' do
+    user = create(:user)
+    create(:job_category)
+
+    login_as user
+    visit new_profile_job_category_path
+
+    alert_text = 'Atenção: Os dados cadastrados não poderão ser alterados após salvar. Preencha com cuidado.'
+    expect(page).to have_content alert_text
+  end
+
+  it 'e vê um link para retornar à página de meu perfil' do
+    user = create(:user)
+    create(:job_category)
+
+    login_as user
+    visit new_profile_job_category_path
+
+    expect(page).to have_link 'Voltar', href: user_profile_path
+  end
 end

--- a/spec/system/profile_job_categories/user_create_profile_job_category_spec.rb
+++ b/spec/system/profile_job_categories/user_create_profile_job_category_spec.rb
@@ -95,4 +95,18 @@ describe 'Usuário cadastra categoria de trabalho em seu perfil' do
 
     expect(page).to have_link 'Voltar', href: user_profile_path
   end
+
+  it 'mas não pode cadastrar a mesma categoria duas ou mais vezes.' do
+    user = create(:user)
+    user.profile.profile_job_categories.create(job_category: create(:job_category, name: 'Web Design'))
+
+    login_as user
+    visit new_profile_job_category_path
+    select 'Web Design', from: 'Categoria'
+    click_on 'Salvar'
+
+    expect(page).to have_current_path new_profile_job_category_path
+    expect(page).to have_content 'Não foi possível adicionar a categoria de trabalho'
+    expect(page).to have_content 'Categoria de trabalho já está em uso'
+  end
 end


### PR DESCRIPTION
Essa PR aborda e resolve #36

Foi criado um formulário para o usuário cadastrar categorias de trabalho, com descrições, em seu perfil. O usuário deverá acessar esse formulário através da página 'Meu Perfil', clicando em seu nome na barra de navegação. 
![image](https://github.com/TreinaDev/td11-portfoliorrr/assets/111306649/e63d4e43-6fa5-4a09-903a-8924f66aef28)

Esse cadastro de categoria de trabalho deve obedecer as seguintes regras de negócio:

- O usuário deve cadastrar em seu perfil uma categoria de trabalho já existente na plataforma;
- O usuário pode adicionar uma descrição à essa categoria de trabalho, ou deixá-la em branco;
- O usuário pode adicionar categorias de trabalho somente para seu perfil, não podendo fazê-lo no perfil de outros usuários;
- O usuário deve estar autenticado para cadastrar uma categoria de trabalho em seu perfil
- O usuário pode cadastrar uma categoria de trabalho apenas uma vez no seu perfil, não podendo haver dois registros da mesma categoria para um único usuário;

![image](https://github.com/TreinaDev/td11-portfoliorrr/assets/111306649/ba91bbec-a83e-4524-b080-51c56226b665)

![image](https://github.com/TreinaDev/td11-portfoliorrr/assets/111306649/f80b43f7-f658-44ce-bc03-d754d753b0a1)

Se não houverem categorias de trabalho disponíveis para escolha na plataforma, a rota deverá estar bloqueada e redirecionar qualquer tentativa de acesso para a tela de Meu Perfil (user_profile_path).

![image](https://github.com/TreinaDev/td11-portfoliorrr/assets/111306649/163125e2-1130-45be-a363-3f7773908b7d)

Essa PR aborda apenas o ato de cadastrar uma categoria de trabalho no perfil, conforme priorização da equipe. No momento, o usuário não será capaz de editar ou remover uma categoria adicionada, portanto adicionamos um alerta na tela de formulário para que ele esteja ciente dessa situação. 