### PR TITLE
Implementa busca por nome, categoria ou cidade.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,8 @@ gem 'cpf_cnpj'
 
 gem 'cssbundling-rails'
 gem 'devise'
+
+gem 'faker'
 gem 'jbuilder'
 gem 'jsbundling-rails'
 gem 'puma', '~> 6.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -122,6 +122,8 @@ GEM
     factory_bot_rails (6.4.3)
       factory_bot (~> 6.4)
       railties (>= 5.0.0)
+    faker (3.2.3)
+      i18n (>= 1.8.11, < 2)
     ferrum (0.14)
       addressable (~> 2.5)
       concurrent-ruby (~> 1.1)
@@ -314,6 +316,7 @@ DEPENDENCIES
   debug
   devise
   factory_bot_rails
+  faker
   jbuilder
   jsbundling-rails
   puma (~> 6.0)

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -9,10 +9,10 @@ class ProfilesController < ApplicationController
   end
 
   def search
-    query = params[:query]
+    @query = params[:query]
 
-    return redirect_back(fallback_location: root_path, alert: t('.error')) if query.blank?
+    return redirect_back(fallback_location: root_path, alert: t('.error')) if @query.blank?
 
-    @users = User.search_by_full_name(query)
+    @profiles = Profile.advanced_search(@query)
   end
 end

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -10,11 +10,23 @@ class Profile < ApplicationRecord
 
   has_many :connections, foreign_key: :followed_profile_id, dependent: :destroy, inverse_of: :followed_profile
 
+  has_many :profile_job_categories, dependent: :destroy
+
+  has_many :job_categories, through: :profile_job_categories
+
   accepts_nested_attributes_for :personal_info
 
   after_create :create_personal_info!
 
   delegate :full_name, to: :user
+
+  def self.advanced_search(search_query)
+    left_outer_joins(:job_categories, :personal_info, :user).where(
+      "job_categories.name LIKE :term OR
+                 personal_infos.city LIKE :term OR
+                 users.full_name LIKE :term", { term: "%#{sanitize_sql_like(search_query)}%" }
+    ).uniq
+  end
 
   def followers_count
     followers.active.count

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -17,11 +17,6 @@ class User < ApplicationRecord
 
   after_create :'create_profile!'
 
-  def self.search_by_full_name(query)
-    where('full_name LIKE ?',
-          "%#{sanitize_sql_like(query)}%")
-  end
-
   def description
     if admin?
       "#{full_name.split(' ').first} (Admin)"

--- a/app/views/profiles/search.html.erb
+++ b/app/views/profiles/search.html.erb
@@ -1,11 +1,24 @@
 <h2>Resultado da Pesquisa</h2>
 
-<% if @users.any? %>
-  <ul>
-    <% @users.each do |user| %>
-      <li><%= user.full_name %></li>
+<% if @profiles.any? %>
+  <h3><%= @profiles.count %> <%= t('profiles.search.results', count: @profiles.count) %> para: <%= @query %></h3>
+    <% @profiles.each do |profile| %>
+    <div class="w-50 mt-5 p-3 border-bottom border-1">
+      <div class="search-result">
+        <h3 class="text-center"><%= link_to profile.full_name, profile %></h3>
+        <% if profile.personal_info.city && profile.personal_info.state %>
+          <p class="text-center"><%= profile.personal_info.city %> - <%= profile.personal_info.state %></p>
+        <% end %>
+        <% if profile.job_categories.any? %>
+          <div class="d-flex gap-3 justify-content-center">
+            <% profile.job_categories.first(3).each do |category| %>
+              <p class="border border-2 p-2 bg-dark-subtle"> <%= category.name %> </p>
+            <% end %>
+          </div>
+        <% end %>
+      </div>
+    </div>
     <% end %>
-  </ul>
 <% else %>
-  <p>Não encontramos nenhum perfil com esse nome</p>
+  <p>Nenhum perfil encontrado com: <%= @query %></p>
 <% end %>

--- a/config/locales/profile.pt-BR.yml
+++ b/config/locales/profile.pt-BR.yml
@@ -10,3 +10,6 @@ pt-BR:
   profiles:
     search:
       error: 'Você precisa informar um nome para fazer a pesquisa'
+      results:
+        one: 'resultado'
+        other: 'resultados'

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -5,18 +5,32 @@ gabriel = User.create(email: 'gabriel@campos.com', password: 'oigaleraaa', full_
 post_joao_1 = joao.posts.create(title: 'Turma 11', content: 'A melhor turma de todas')
 post_joao_2 = joao.posts.create(title: 'Warehouses', content: 'Vamos aprender a fazer um app de gestão de galpões')
 post_joao_3 = joao.posts.create(title: 'Rubocop: devo usar?', content: 'No começo, tem que aprender na marra.')
+
 post_andre_1 = andre.posts.create(title: 'Pull Request', content: 'Façam o Pull Request na main antes de usar o código nas branches dos outros')
 post_andre_2 = andre.posts.create(title: 'Desafios Exclusivos', content: 'Eu fiz o batalha naval mesmo para desafiar a galera')
 post_andre_3 = andre.posts.create(title: 'SOLID', content: 'Hoje, vamos falar sobre boas prática de desenvolvimento de código')
+
 post_gabriel_1 = gabriel.posts.create(title: 'Como fazer uma app Vue', content: 'Não esqueça de usar o app.mount')
 post_gabriel_2 = gabriel.posts.create(title: 'Boas práticas em Zoom', content: 'Hoje vamos falar sobre breakout rooms!')
 post_gabriel_3 = gabriel.posts.create(title: 'Robô Saltitante: como resolver?', content: 'Vamos falar sobre a tarefa mais complexa do Code Saga!')
+
+joao.profile.personal_info.update(city: 'São Paulo', state: 'SP')
+andre.profile.personal_info.update(city: 'Cuiabá', state: 'MT')
+gabriel.profile.personal_info.update(city: 'Salvador', state: 'BA')
 
 JobCategory.create(name: 'Web Design')
 JobCategory.create(name: 'Programador Full Stack')
 JobCategory.create(name: 'Ruby on Rails')
 
-ProfileJobCategory.create(profile: User.last.profile, job_category: JobCategory.last)
+ProfileJobCategory.create(profile: gabriel.profile, job_category: JobCategory.first)
+
+ProfileJobCategory.create(profile: andre.profile, job_category: JobCategory.first)
+ProfileJobCategory.create(profile: andre.profile, job_category: JobCategory.second)
+
+ProfileJobCategory.create(profile: joao.profile, job_category: JobCategory.first)
+ProfileJobCategory.create(profile: joao.profile, job_category: JobCategory.second)
+ProfileJobCategory.create(profile: joao.profile, job_category: JobCategory.last)
+
 
 Connection.create(follower: joao.profile, followed_profile: andre.profile)
 Connection.create(follower: gabriel.profile, followed_profile: andre.profile)

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,8 +1,8 @@
 FactoryBot.define do
   factory :user do
     full_name { 'Joao Almeida' }
-    citizen_id_number { '92767398078' }
-    email { 'joao@almeida.com' }
+    citizen_id_number { Faker::IDNumber.brazilian_citizen_number }
+    email { Faker::Internet.email }
     password { '123456' }
   end
 end

--- a/spec/models/profile_spec.rb
+++ b/spec/models/profile_spec.rb
@@ -100,4 +100,65 @@ RSpec.describe Profile, type: :model do
       expect(followed.profile.inactive_follower?(follower.profile)).to eq false
     end
   end
+
+  describe '#advanced_search' do
+    it 'encontra usuários procurando pelo nome' do
+      create(:user, full_name: 'João')
+      create(:user, full_name: 'André')
+      create(:user, full_name: 'Gyodai')
+      create(:user, full_name: 'Rodrigo Gyodai')
+      create(:user, full_name: 'Rosemilson')
+      create(:user, full_name: 'Rosemilson Barbosa')
+
+      found_profiles = Profile.advanced_search('ro')
+
+      expect(found_profiles.count).to eq(3)
+      expect(found_profiles[0].full_name).to eq('Rodrigo Gyodai')
+      expect(found_profiles[1].full_name).to eq('Rosemilson')
+      expect(found_profiles[2].full_name).to eq('Rosemilson Barbosa')
+    end
+
+    it 'encontra usuários procurando por cidade' do
+      joao = create(:user, full_name: 'João')
+      andre = create(:user, full_name: 'André')
+      joao.profile.personal_info.update!(city: 'São Paulo')
+      andre.profile.personal_info.update!(city: 'Curitiba')
+
+      found_profiles = Profile.advanced_search('são')
+
+      expect(found_profiles.count).to eq(1)
+      expect(found_profiles[0].full_name).to eq('João')
+    end
+
+    it 'encontra usuários procurando por categoria de trabalho' do
+      joao = create(:user, full_name: 'João')
+      andre = create(:user, full_name: 'André')
+      first_category = create(:job_category, name: 'Web Design')
+      second_category = create(:job_category, name: 'Modelagem 3D')
+      joao.profile.profile_job_categories.create!(job_category: first_category)
+      andre.profile.profile_job_categories.create!(job_category: second_category)
+
+      found_profiles = Profile.advanced_search('web')
+
+      expect(found_profiles.count).to eq(1)
+      expect(found_profiles[0].full_name).to eq('João')
+    end
+
+    it 'encontra resultados mistos' do
+      joao = create(:user, full_name: 'João')
+      andre = create(:user, full_name: 'André')
+      cesar = create(:user, full_name: 'César')
+      gabriel = create(:user, full_name: 'Gabriel')
+      first_category = create(:job_category, name: 'Jornalista')
+      second_category = create(:job_category, name: 'Modelagem 3D')
+      andre.profile.profile_job_categories.create!(job_category: first_category)
+      joao.profile.profile_job_categories.create!(job_category: second_category)
+      cesar.profile.personal_info.update!(city: 'São João')
+
+      found_profiles = Profile.advanced_search('jo')
+
+      expect(found_profiles.count).to eq(3)
+      expect(found_profiles).to_not include gabriel.profile
+    end
+  end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,52 +1,6 @@
 require 'rails_helper'
 
 RSpec.describe User, type: :model do
-  describe '#search' do
-    it 'retorna uma instância de acordo com o valor da procura' do
-      create(
-        :user,
-        email: 'joao@almeida.com',
-        password: '123456',
-        full_name: 'João CampusCode Almeida',
-        citizen_id_number: '00752496263'
-      )
-      create(
-        :user,
-        email: 'akaninja@email.com',
-        password: 'usemogit',
-        full_name: 'André Kanamura',
-        citizen_id_number: '00232728305'
-      )
-      create(
-        :user,
-        email: 'gabriel@campos.com',
-        password: 'oigaleraaa',
-        full_name: 'Gabriel Campos',
-        citizen_id_number: '02742567895'
-      )
-
-      result = User.search_by_full_name('amp')
-
-      expect(result.all.count).to eq 2
-      expect(result.first.full_name).to eq 'João CampusCode Almeida'
-      expect(result.last.full_name).to eq 'Gabriel Campos'
-    end
-
-    it 'Retorna nil se nenhum resultado for encontrado' do
-      create(
-        :user,
-        email: 'joao@almeida.com',
-        password: '123456',
-        full_name: 'João CampusCode Almeida',
-        citizen_id_number: '00752496263'
-      )
-
-      result = User.search_by_full_name('abobra')
-
-      expect(result.all.count).to eq 0
-    end
-  end
-
   describe '#valid?' do
     context 'presença' do
       it 'nome completo não pode ficar em branco' do

--- a/spec/system/users_searchs_others_users_spec.rb
+++ b/spec/system/users_searchs_others_users_spec.rb
@@ -1,23 +1,14 @@
 require 'rails_helper'
 
 describe 'Usuário busca outros usuários' do
-  it 'só pode ver página de resultados se estiver logado' do
-    visit search_profiles_path
-
-    expect(current_path).to eq new_user_session_path
-  end
-
-  it 'mas não vê o formulário por não estar logado' do
-    visit root_path
-
-    expect(page).not_to have_field 'Busca de Perfis'
-    expect(page).not_to have_button 'Pesquisar'
-  end
-
-  it 'com sucesso e vê uma lista de nomes de usuários cadastrados' do
-    create(:user, full_name: 'Horácio Fernandes', email: 'horacio@email.com', citizen_id_number: '00752496263')
-    create(:user, full_name: 'Geraldo José', email: 'geraldo@email.com', citizen_id_number: '00232728305')
-    user = create(:user, full_name: 'Geralda', citizen_id_number: '02742567895')
+  it 'com sucesso e vê lista de perfis encontrados' do
+    user = create(:user, full_name: 'Horácio Fernandes', email: 'horacio@email.com', citizen_id_number: '00752496263')
+    another_user = create(:user, full_name: 'Geralda', citizen_id_number: '02742567895')
+    other_user = create(:user, full_name: 'Geraldo José', email: 'geraldo@email.com', citizen_id_number: '00232728305')
+    another_user.profile.personal_info.update!(city: 'São Paulo', state: 'São Paulo')
+    other_user.profile.personal_info.update!(city: 'Cuiabá', state: 'Mato Grosso')
+    job_category = create(:job_category, name: 'Ruby on Rails')
+    another_user.profile.profile_job_categories.create!(job_category:)
 
     login_as user
     visit root_path
@@ -25,9 +16,13 @@ describe 'Usuário busca outros usuários' do
     click_on 'Pesquisar'
 
     expect(current_path).to eq search_profiles_path
+    expect(page).to have_content('2 resultados para: gErAl')
     expect(page).not_to have_content 'Horácio Fernandes'
-    expect(page).to have_content 'Geraldo José'
-    expect(page).to have_content 'Geralda'
+    expect(page).to have_link 'Geraldo José'
+    expect(page).to have_link 'Geralda'
+    expect(page).to have_content 'São Paulo'
+    expect(page).to have_content 'Cuiabá'
+    expect(page).to have_content 'Ruby on Rails'
     within 'h2' do
       expect(page).to have_content 'Resultado da Pesquisa'
     end
@@ -41,7 +36,20 @@ describe 'Usuário busca outros usuários' do
     fill_in 'Buscar Perfil', with: 'Dorotéia'
     click_on 'Pesquisar'
 
-    expect(page).to have_content 'Não encontramos nenhum perfil com esse nome'
+    expect(page).to have_content 'Nenhum perfil encontrado com: Dorotéia'
+  end
+
+  it 'só pode ver página de resultados se estiver logado' do
+    visit search_profiles_path
+
+    expect(current_path).to eq new_user_session_path
+  end
+
+  it 'mas não vê o formulário por não estar logado' do
+    visit root_path
+
+    expect(page).not_to have_field 'Busca de Perfis'
+    expect(page).not_to have_button 'Pesquisar'
   end
 
   it 'mas campo de pesquisa não pode ficar em branco' do
@@ -54,5 +62,23 @@ describe 'Usuário busca outros usuários' do
 
     expect(current_path).to eq root_path
     expect(page).to have_content 'Você precisa informar um nome para fazer a pesquisa'
+  end
+
+  it 'e usuário só aparece uma vez' do
+    user = create(:user, full_name: 'João')
+    first_job_category = create(:job_category, name: 'Jornalista')
+    second_job_category = create(:job_category, name: 'Jogador')
+    user.profile.personal_info.update!(city: 'São João')
+    user.profile.profile_job_categories.create!(job_category: first_job_category)
+    user.profile.profile_job_categories.create!(job_category: second_job_category)
+
+    login_as user
+    visit root_path
+    fill_in 'Buscar Perfil', with: 'jo'
+    click_on 'Pesquisar'
+
+    within '.search-result' do
+      expect(page).to have_link('João').once
+    end
   end
 end


### PR DESCRIPTION
## Esse PR aborda e resolve #27 

- [x] Cria método advanced_search no model Profile para realizar busca por nome, categoria ou cidade.
- [x] Remove método search_by_full_name que não será mais utilizado. 
- [x] Adiciona seeds para personal_info e profile_job_categories de usuários. 
- [x] Adiciona gem 'faker' e utiliza a gem para gerar emails e cpfs nas factories de usuário.

Busca por cidade:
![image](https://github.com/TreinaDev/td11-portfoliorrr/assets/105087841/aad626b9-b9dc-4537-a322-6af2cee4118b)
Busca por categoria de trabalho:
![image](https://github.com/TreinaDev/td11-portfoliorrr/assets/105087841/8d6ca5e6-b30f-4a19-b51f-f3a18cacd5d0)
Busca por nome:
![image](https://github.com/TreinaDev/td11-portfoliorrr/assets/105087841/60fc645f-bf4c-4ef6-8aa4-6147953180ec)
