### PR TITLE
Endpoint API - Busca de usuários por categorias de trabalho

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,10 +3,10 @@
 O Portfoliorrr é uma rede social com funcionalidades de portfólio para pessoas que querem compartilhar o seu trabalho e procurar outros trabalhos, seja para buscar inspiração ou novos conhecimentos.
 
 ## Conteúdo
-* [Informações técnicas](https://github.com/TreinaDev/td11-portfoliorrr#informacoes-tecnicas)
-* [Como configurar a aplicação](https://github.com/TreinaDev/td11-portfoliorrr#como-configurar-a-aplicacao)
-* [Como visualizar a aplicação no navegador](https://github.com/TreinaDev/td11-portfoliorrr#como-visualizar-a-aplicacao-no-navegador)
-* [Documentação da API](https://github.com/TreinaDev/td11-portfoliorrr#documentacao-da-api)
+* [Informações técnicas](https://github.com/TreinaDev/td11-portfoliorrr?tab=readme-ov-file#informa%C3%A7%C3%B5es-t%C3%A9cnicas)
+* [Como configurar a aplicação](https://github.com/TreinaDev/td11-portfoliorrr?tab=readme-ov-file#como-configurar-a-aplica%C3%A7%C3%A3o)
+* [Como visualizar a aplicação no navegador](https://github.com/TreinaDev/td11-portfoliorrr?tab=readme-ov-file#como-visualizar-a-aplica%C3%A7%C3%A3o-no-navegador)
+* [Documentação da API](https://github.com/TreinaDev/td11-portfoliorrr?tab=readme-ov-file#documenta%C3%A7%C3%A3o-da-api)
 
 ## Informações técnicas
 * Versão Ruby: 3.2.2

--- a/api_doc.md
+++ b/api_doc.md
@@ -33,9 +33,7 @@ Retorna a lista com todas as categorias de trabalho. (Status: 200)
 Retorno esperado caso não tenham categorias cadastradas. (Status: 200):
 
 ```json
-{
-  "message": "Não há categorias de trabalho cadastradas. Contate um admin do Portfoliorrr."
-}
+  []
 ```
 
 ### Erros tratados
@@ -47,5 +45,94 @@ Retorno esperado:
 ```json
 { 
   "error": ["Houve um erro interno no servidor ao processar sua solicitação."]
+}
+```
+
+## 2. Buscar por usuários na plataforma Portifoliorrr através dos campos `job_category.name` e `profile_job_category.description` 
+
+### Endpoint
+
+query: Parâmetro que recebe string a ser buscada nos campos listados no título.
+
+```shell
+GET /api/v1/profiles/search?search=query
+```
+
+Retorna uma lista com todos os usuários referetes a busca. (Status: 200)
+
+```json
+[
+  {
+      "user_id": 1,
+      "full_name": "João CampusCode Almeida",
+      "job_categories": [
+          {
+            "title": "Web Design",
+            "description": null
+          },
+          {
+            "title": "Programador Full Stack",
+            "description": null
+          },
+          {
+            "title": "Ruby on Rails",
+            "description": null
+          }
+      ]
+  },
+  {
+      "user_id": 3,
+      "full_name": "Gabriel Campos",
+      "job_categories": [
+          {
+            "title": "Web Design",
+            "description": null
+          },
+          {
+            "title": "Ruby on Rails",
+            "description": "faço umas app daora"
+          },
+          {
+            "title": "Programador Full Stack",
+            "description": "faço umas app loka"
+          }
+      ]
+  }
+]
+```
+
+Retorno esperado caso a busca não retorne resultados. (Status: 200):
+
+```json
+  []
+```
+
+### Erros tratados
+
+Erro interno de servidor (Status: 500)
+
+Retorno esperado:
+
+```json
+{ 
+  "error": ["Houve um erro interno no servidor ao processar sua solicitação."]
+}
+```
+
+Erro para query de busca vazia (Status: 400)
+
+Este erro acontece quando a busca é feita sem informar o parâmetro obrigatório query. Exemplos de buscas que retornarão este erro:
+
+```shell
+GET /api/v1/profiles/search?search=
+
+GET /api/v1/profiles/search/
+```
+
+Retorno esperado:
+
+```json
+{
+"error": "É necessário fornecer um parâmetro de busca"
 }
 ```

--- a/api_doc.md
+++ b/api_doc.md
@@ -44,7 +44,7 @@ Retorno esperado:
 
 ```json
 { 
-  "error": ["Houve um erro interno no servidor ao processar sua solicitação."]
+  { "error": "Houve um erro interno no servidor ao processar sua solicitação." }
 }
 ```
 
@@ -58,7 +58,7 @@ query: Parâmetro que recebe string a ser buscada nos campos listados no título
 GET /api/v1/profiles/search?search=query
 ```
 
-Retorna uma lista com todos os usuários referetes a busca. (Status: 200)
+Retorna uma lista com todos os usuários referentes a busca. (Status: 200)
 
 ```json
 [

--- a/app/controllers/api/v1/profiles_controller.rb
+++ b/app/controllers/api/v1/profiles_controller.rb
@@ -1,0 +1,10 @@
+module Api
+  module V1
+    class ProfilesController < ApiController
+      def search
+        profiles = Profile.search_by_job_categories(params[:search])
+        render status: :ok, json: profiles.as_json(except: %i[created_at updated_at])
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/profiles_controller.rb
+++ b/app/controllers/api/v1/profiles_controller.rb
@@ -2,8 +2,8 @@ module Api
   module V1
     class ProfilesController < ApiController
       def search
-        profiles = Profile.search_by_job_categories(params[:search])
-        render status: :ok, json: profiles.as_json(except: %i[created_at updated_at])
+        profiles = Profile.get_profile_job_categories_json(params[:search])
+        render status: :ok, json: profiles.as_json
       end
     end
   end

--- a/app/controllers/api/v1/profiles_controller.rb
+++ b/app/controllers/api/v1/profiles_controller.rb
@@ -2,8 +2,12 @@ module Api
   module V1
     class ProfilesController < ApiController
       def search
-        profiles = Profile.get_profile_job_categories_json(params[:search])
-        render status: :ok, json: profiles.as_json
+        if params[:search].blank?
+          render status: :bad_request, json: { error: 'É necessário fornecer um parâmetro de busca' }
+        else
+          profiles = Profile.get_profile_job_categories_json(params[:search])
+          render status: :ok, json: profiles.as_json
+        end
       end
     end
   end

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -33,6 +33,14 @@ class Profile < ApplicationRecord
     ).uniq
   end
 
+  def self.search_by_job_categories(query)
+    left_outer_joins(:job_categories, :profile_job_categories).where(
+      "job_categories.name LIKE :term OR
+                 profile_job_categories.description LIKE :term",
+                 { term: "%#{sanitize_sql_like(query)}%" }
+    ).uniq
+  end
+
   def followers_count
     followers.active.count
   end

--- a/app/models/profile_job_category.rb
+++ b/app/models/profile_job_category.rb
@@ -4,4 +4,11 @@ class ProfileJobCategory < ApplicationRecord
 
   validates :job_category_id, presence: true
   validates :job_category_id, uniqueness: { scope: :profile_id }
+
+  def self.generate_profile_job_categories_json(profile_id)
+    profile_job_categories = where(profile_id:)
+    profile_job_categories.map do |pjc|
+      { title: pjc.job_category.name, description: pjc.description }
+    end
+  end
 end

--- a/bin/dev
+++ b/bin/dev
@@ -6,6 +6,6 @@ if gem list --no-installed --exact --silent foreman; then
 fi
 
 # Default to port 3000 if not specified
-export PORT="${PORT:-4000}"
+export PORT="${PORT:-3000}"
 
 exec foreman start -f Procfile.dev "$@"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -35,6 +35,9 @@ Rails.application.routes.draw do
   namespace :api do
     namespace :v1 do 
       resources :job_categories, only: %i[index]
+      resources :profiles, only: [] do
+        get 'search', on: :collection
+      end
     end
   end
 end

--- a/spec/factories/posts.rb
+++ b/spec/factories/posts.rb
@@ -3,5 +3,6 @@ FactoryBot.define do
     user
     title { 'Tenho Opiniões' }
     content { 'E não são poucas' }
+    edited_at { Time.zone.now }
   end
 end

--- a/spec/requests/apis/v1/search_user_by_job_categories_spec.rb
+++ b/spec/requests/apis/v1/search_user_by_job_categories_spec.rb
@@ -2,41 +2,40 @@ require 'rails_helper'
 
 describe 'Api busca usuários por categoria de trabalho' do
   context 'GET api/v1/profiles' do
-    it 'com sucesso' do
-      ruby = create(:job_category, name: 'Ruby on Rails') # AB
-      web_design = create(:job_category, name: 'Web Design') #CD
+    it 'com sucesso se encontrar o parâmetro no nome da categoria ou na descrição dela' do
+      ruby = create(:job_category, name: 'Ruby on Rails')
+      web_design = create(:job_category, name: 'Web Design')
+      front_end = create(:job_category, name: 'Front End')
       user_a = create(:user)
-      user_a.profile.profile_job_categories.create!(job_category: ruby, description: 'Eu uso ruby pra codar')
+      user_a.profile.profile_job_categories.create!(job_category: ruby, description: 'Eu amo codar')
       user_b = create(:user, full_name: 'André Porteira', citizen_id_number: '418.767.220-61', email: 'andre@email.com')
       user_b.profile.profile_job_categories.create!(job_category: web_design, description: 'EU trabalho com css.')
-      #user_c = create(:user, full_name: 'Moisés Campus', citizen_id_number: '002.488.770-62', email: 'moises@email.com')
-      #user_c.profile.profile_job_categories.create!(job_category: ruby, description: 'Eu gosto de programar.')
-      #user_d = create(:user, full_name: 'Eliseu Ramos', citizen_id_number: '630.010.360-95', email: 'eliseu@email.com')
-      #user_d.profile.profile_job_categories.create!(job_category: web_design, description: 'Eu uso html e ruby')
+      user_c = create(:user, full_name: 'Moisés Campus', citizen_id_number: '002.488.770-62', email: 'moises@email.com')
+      user_c.profile.profile_job_categories.create!(job_category: web_design, description: 'Eu uso ruby')
+      user_c.profile.profile_job_categories.create!(job_category: front_end, description: 'Eu uso Bootstrap.')
 
       get '/api/v1/profiles/search', params: { search: 'ruby' }
 
       expect(response.status).to eq 200
       expect(response.content_type).to include 'application/json'
       json_response = JSON.parse(response.body)
-      expect(json_response.length).to eq 1
+      expect(json_response.length).to eq 2
       expect(json_response.class).to eq Array
       expect(json_response.first.keys).not_to include 'created_at'
       expect(json_response.first.keys).not_to include 'updated_at'
-      expect(json_response.first['id']).to eq 1
+      expect(json_response.first['user_id']).to eq 1
       expect(json_response.first['full_name']).to eq 'Joao Almeida'
-      expect(json_response.first['job_categories']).to eq [{ name: 'Ruby on Rails' }]
-      expect(json_response.second['id']).not_to eq 2
-      expect(json_response.second['full_name']).not_to eq 'André Porteira'
-      expect(json_response.second['job_categories']).not_to eq [{ name: 'Web Design' }]
+      expect(json_response.first['job_categories']).to eq [{ 'title' => 'Ruby on Rails',
+                                                             'description' => 'Eu amo codar' }]
+      expect(json_response.second['user_id']).to eq 3
+      expect(json_response.second['full_name']).to eq 'Moisés Campus'
+      expect(json_response.second['job_categories']).to eq [{ 'title' => 'Web Design', 'description' => 'Eu uso ruby' },
+                                                            { 'title' => 'Front End',
+                                                              'description' => 'Eu uso Bootstrap.' }]
     end
 
     pending 'não encontrar nenhum usuário'
+    pending 'e não recebe um parâmetro de busca'
     pending 'retorna um erro interno do servidor'
   end
 end
-
-# Profile.where(id: ProfileJobCategory.where.associated(:job_category).where("name LIKE '%#{search}%'").pluck(:profile_id)) >> pesquisa no nome da categoria
-# Profile.where(id: ProfileJobCategory.where("description like '%#{search}%'").pluck(:profile_id)) >> pesquisa na descrição da categoria de perfil
-
-# 'Ruby on Rails' >> search = 'ruby'

--- a/spec/requests/apis/v1/search_user_by_job_categories_spec.rb
+++ b/spec/requests/apis/v1/search_user_by_job_categories_spec.rb
@@ -1,0 +1,42 @@
+require 'rails_helper'
+
+describe 'Api busca usuários por categoria de trabalho' do
+  context 'GET api/v1/profiles' do
+    it 'com sucesso' do
+      ruby = create(:job_category, name: 'Ruby on Rails') # AB
+      web_design = create(:job_category, name: 'Web Design') #CD
+      user_a = create(:user)
+      user_a.profile.profile_job_categories.create!(job_category: ruby, description: 'Eu uso ruby pra codar')
+      user_b = create(:user, full_name: 'André Porteira', citizen_id_number: '418.767.220-61', email: 'andre@email.com')
+      user_b.profile.profile_job_categories.create!(job_category: web_design, description: 'EU trabalho com css.')
+      #user_c = create(:user, full_name: 'Moisés Campus', citizen_id_number: '002.488.770-62', email: 'moises@email.com')
+      #user_c.profile.profile_job_categories.create!(job_category: ruby, description: 'Eu gosto de programar.')
+      #user_d = create(:user, full_name: 'Eliseu Ramos', citizen_id_number: '630.010.360-95', email: 'eliseu@email.com')
+      #user_d.profile.profile_job_categories.create!(job_category: web_design, description: 'Eu uso html e ruby')
+
+      get '/api/v1/profiles/search', params: { search: 'ruby' }
+
+      expect(response.status).to eq 200
+      expect(response.content_type).to include 'application/json'
+      json_response = JSON.parse(response.body)
+      expect(json_response.length).to eq 1
+      expect(json_response.class).to eq Array
+      expect(json_response.first.keys).not_to include 'created_at'
+      expect(json_response.first.keys).not_to include 'updated_at'
+      expect(json_response.first['id']).to eq 1
+      expect(json_response.first['full_name']).to eq 'Joao Almeida'
+      expect(json_response.first['job_categories']).to eq [{ name: 'Ruby on Rails' }]
+      expect(json_response.second['id']).not_to eq 2
+      expect(json_response.second['full_name']).not_to eq 'André Porteira'
+      expect(json_response.second['job_categories']).not_to eq [{ name: 'Web Design' }]
+    end
+
+    pending 'não encontrar nenhum usuário'
+    pending 'retorna um erro interno do servidor'
+  end
+end
+
+# Profile.where(id: ProfileJobCategory.where.associated(:job_category).where("name LIKE '%#{search}%'").pluck(:profile_id)) >> pesquisa no nome da categoria
+# Profile.where(id: ProfileJobCategory.where("description like '%#{search}%'").pluck(:profile_id)) >> pesquisa na descrição da categoria de perfil
+
+# 'Ruby on Rails' >> search = 'ruby'


### PR DESCRIPTION
Essa PR aborda e resolve #37 .

O endpoint espera um parâmetro (`search`), que é usado para buscar usuários do Portfoliorrr que possuam esse texto no nome da categoria de trabalho ou na descrição que foram adicionadas em seu perfil. Usuários que não possuem categorias de trabalho cadastradas em seu perfil não serão encontrados através dessa busca.

- Caso o endpoint não receba o parâmetro, ele retorna um status de `bad_request` com mensagem de erro. 
  - Exemplos de `bad_request`:
    - `http://localhost:3000/api/v1/profiles/search`
    - `http://localhost:3000/api/v1/profiles/search/?search=`

![image](https://github.com/TreinaDev/td11-portfoliorrr/assets/111306649/975d52ff-5463-4c2d-9b56-0c5a01b9ec13)

- Caso o endpoint realize a pesquisa mas não encontre resultados, ele retorna uma array vazia;
- Se um usuário der múltiplas combinações com a pesquisa, ele será listado apenas uma vez;

Cada usuário encontrado retornará as seguintes informações:
- `user_id`: id da tabela `users` correspondente ao usuário encontrado;
- `full_name`: nome completo do usuário;
- `job_categories`: uma array com todas as categorias de trabalho e descrições adicionadas pelo usuário;
  - `title`: título da categoria de trabalho;
  - `description`: descrição da categoria de trabalho adicionada pelo usuário. Caso retorne nulo, significa que o usuário não cadastrou uma descrição para esta categoria de trabalho, já que o campo é opcional
  
![image](https://github.com/TreinaDev/td11-portfoliorrr/assets/111306649/0c349856-7fef-42f6-97f1-9b0f8f2019ca)

A documentação de API também foi atualizada com as instruções de uso desse endpoint.