### PR TITLE
Adiciona status de trabalho ao perfil

### DIFF
--- a/app/controllers/api/v1/profiles_controller.rb
+++ b/app/controllers/api/v1/profiles_controller.rb
@@ -5,7 +5,7 @@ module Api
         if params[:search].blank?
           render status: :bad_request, json: { error: 'É necessário fornecer um parâmetro de busca' }
         else
-          profiles = Profile.get_profile_job_categories_json(params[:search])
+          profiles = Profile.open_to_work.get_profile_job_categories_json(params[:search])
           render status: :ok, json: profiles.as_json
         end
       end

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -22,4 +22,16 @@ class ProfilesController < ApplicationController
 
     @profiles = Profile.advanced_search(@query)
   end
+
+  def work_unavailable
+    @profile = current_user.profile
+    @profile.unavailable!
+    redirect_to profile_path(@profile), notice: 'Alteração salva com sucesso'
+  end
+
+  def open_to_work
+    @profile = current_user.profile
+    @profile.open_to_work!
+    redirect_to profile_path(@profile), notice: 'Alteração salva com sucesso'
+  end
 end

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -26,12 +26,12 @@ class ProfilesController < ApplicationController
   def work_unavailable
     @profile = current_user.profile
     @profile.unavailable!
-    redirect_to profile_path(@profile), notice: 'Alteração salva com sucesso'
+    redirect_to profile_path(@profile), notice: t('.success')
   end
 
   def open_to_work
     @profile = current_user.profile
     @profile.open_to_work!
-    redirect_to profile_path(@profile), notice: 'Alteração salva com sucesso'
+    redirect_to profile_path(@profile), notice: t('.success')
   end
 end

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -20,7 +20,7 @@ class Profile < ApplicationRecord
   accepts_nested_attributes_for :education_infos
 
   after_create :create_personal_info!
-  enum work_status: { unavailable: 0, open_to_work: 1 }
+  enum work_status: { unavailable: 0, open_to_work: 10 }
 
   delegate :full_name, to: :user
 

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -20,6 +20,7 @@ class Profile < ApplicationRecord
   accepts_nested_attributes_for :education_infos
 
   after_create :create_personal_info!
+  enum work_status: { unavailable: 0, open_to_work: 1 }
 
   delegate :full_name, to: :user
 

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -38,13 +38,14 @@
         </div>
         <div>
           <% if @profile.open_to_work? %>
-            <p>Disponível para trabalho</p>
-            <%= button_to 'Não estou disponível para trabalho', work_unavailable_path, method: :patch if current_user.profile == @profile %>
+            <h5 class="text-success"><%= t Profile.human_attribute_name("work_status.#{@profile.work_status}") %></h5>
+            <%= button_to 'Não estou disponível para trabalho', work_unavailable_path, method: :patch, class: 'btn btn-danger' if current_user.profile == @profile %>
           <% else %>
-            <p>Indisponível para trabalho</p>
-            <%= button_to 'Estou disponível para trabalho', open_to_work_path, method: :patch if current_user.profile == @profile %>
+            <h5 class="text-danger"><%= t Profile.human_attribute_name("work_status.#{@profile.work_status}") %></h5>
+            <%= button_to 'Estou disponível para trabalho', open_to_work_path, method: :patch, class: 'btn btn-success' if current_user.profile == @profile %>
           <% end %>
         </div>
+        <br>
         <div class="w-75">
           <% if current_user.profile != @profile %>
             <% if @profile.following?(current_user.profile) %>

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -36,6 +36,15 @@
             <% end %>
           </div>
         </div>
+        <div>
+          <% if @profile.open_to_work? %>
+            <p>Disponível para trabalho</p>
+            <%= button_to 'Não estou disponível para trabalho', work_unavailable_path, method: :patch if current_user.profile == @profile %>
+          <% else %>
+            <p>Indisponível para trabalho</p>
+            <%= button_to 'Estou disponível para trabalho', open_to_work_path, method: :patch if current_user.profile == @profile %>
+          <% end %>
+        </div>
         <div class="w-75">
           <% if current_user.profile != @profile %>
             <% if @profile.following?(current_user.profile) %>

--- a/config/locales/profile.pt-BR.yml
+++ b/config/locales/profile.pt-BR.yml
@@ -7,12 +7,19 @@ pt-BR:
     attributes:
       profile:
         cover_letter: Resumo Profissional
+      profile/work_status:
+          open_to_work: 'Disponível para trabalho'
+          unavailable: 'Indisponível para trabalho'
   profiles:
     search:
       error: 'Você precisa informar um nome para fazer a pesquisa'
       results:
         one: 'resultado'
         other: 'resultados'
+    work_unavailable:
+      success: Alteração salva com sucesso
+    open_to_work:
+      success: Alteração salva com sucesso
   profile:
     update:
       success: 'Informações pessoais atualizadas com sucesso'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -23,6 +23,9 @@ Rails.application.routes.draw do
     end
   end
 
+  patch 'work_unavailable', controller: :profiles
+  patch 'open_to_work', controller: :profiles
+
   resources :likes, only: %i[create destroy]
   resources :job_categories, only: %i[index create]
   resource :profile, only: %i[edit update], controller: :profile, as: :user_profile do

--- a/db/migrate/20240130131541_add_work_status_to_profiles.rb
+++ b/db/migrate/20240130131541_add_work_status_to_profiles.rb
@@ -1,0 +1,5 @@
+class AddWorkStatusToProfiles < ActiveRecord::Migration[7.1]
+  def change
+    add_column :profiles, :work_status, :integer, default: 1
+  end
+end

--- a/db/migrate/20240130190411_change_default_value_for_work_status.rb
+++ b/db/migrate/20240130190411_change_default_value_for_work_status.rb
@@ -1,0 +1,5 @@
+class ChangeDefaultValueForWorkStatus < ActiveRecord::Migration[7.1]
+  def change
+    change_column_default :profiles, :work_status, 10
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_01_30_131541) do
+ActiveRecord::Schema[7.1].define(version: 2024_01_30_190411) do
   create_table "comments", force: :cascade do |t|
     t.text "message"
     t.integer "post_id", null: false
@@ -85,7 +85,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_01_30_131541) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "pin", default: 0
-    t.datetime "edited_at", default: "2024-01-30 13:56:09"
+    t.datetime "edited_at", default: "2024-01-29 13:19:00"
     t.index ["user_id"], name: "index_posts_on_user_id"
   end
 
@@ -119,7 +119,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_01_30_131541) do
     t.text "cover_letter"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.integer "work_status", default: 1
+    t.integer "work_status", default: 10
     t.index ["user_id"], name: "index_profiles_on_user_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_01_26_133553) do
+ActiveRecord::Schema[7.1].define(version: 2024_01_30_131541) do
   create_table "comments", force: :cascade do |t|
     t.text "message"
     t.integer "post_id", null: false
@@ -85,7 +85,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_01_26_133553) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "pin", default: 0
-    t.datetime "edited_at", default: "2024-01-29 13:19:00"
+    t.datetime "edited_at", default: "2024-01-30 13:56:09"
     t.index ["user_id"], name: "index_posts_on_user_id"
   end
 
@@ -119,6 +119,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_01_26_133553) do
     t.text "cover_letter"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "work_status", default: 1
     t.index ["user_id"], name: "index_profiles_on_user_id"
   end
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -14,7 +14,7 @@ post_gabriel_1 = gabriel.posts.create(title: 'Como fazer uma app Vue', content: 
 post_gabriel_2 = gabriel.posts.create(title: 'Boas práticas em Zoom', content: 'Hoje vamos falar sobre breakout rooms!')
 post_gabriel_3 = gabriel.posts.create(title: 'Robô Saltitante: como resolver?', content: 'Vamos falar sobre a tarefa mais complexa do Code Saga!')
 
-joao.profile.update(cover_letter: 'Sou profissional organizado, esforçado e apaixonado pelo que faço')
+joao.profile.update(cover_letter: 'Sou profissional organizado, esforçado e apaixonado pelo que faço', work_status: 0)
 andre.profile.update(cover_letter: 'Sou profissional organizado, esforçado e apaixonado pelo que faço')
 gabriel.profile.update(cover_letter: 'Sou profissional organizado, esforçado e apaixonado pelo que faço')
 

--- a/spec/requests/apis/v1/search_user_by_job_categories_spec.rb
+++ b/spec/requests/apis/v1/search_user_by_job_categories_spec.rb
@@ -8,11 +8,14 @@ describe 'Api busca usuários por categoria de trabalho' do
       front_end = create(:job_category, name: 'Front End')
       user_a = create(:user)
       user_a.profile.profile_job_categories.create!(job_category: ruby, description: 'Eu amo codar')
-      user_b = create(:user, full_name: 'André Porteira', citizen_id_number: '418.767.220-61', email: 'andre@email.com')
+      user_b = create(:user, full_name: 'André Porteira')
       user_b.profile.profile_job_categories.create!(job_category: web_design, description: 'EU trabalho com css.')
-      user_c = create(:user, full_name: 'Moisés Campus', citizen_id_number: '002.488.770-62', email: 'moises@email.com')
+      user_c = create(:user, full_name: 'Moisés Campus')
       user_c.profile.profile_job_categories.create!(job_category: web_design, description: 'Eu uso ruby')
       user_c.profile.profile_job_categories.create!(job_category: front_end, description: 'Eu uso Bootstrap.')
+      user_d = create(:user, full_name: 'Eliseu Ramos')
+      user_d.profile.unavailable!
+      user_d.profile.profile_job_categories.create!(job_category: ruby, description: 'Eu amo ruby.')
 
       get '/api/v1/profiles/search', params: { search: 'ruby' }
 

--- a/spec/system/profiles/user_changes_work_status_spec.rb
+++ b/spec/system/profiles/user_changes_work_status_spec.rb
@@ -1,30 +1,57 @@
 require 'rails_helper'
 
 describe 'Usuário altera o status de disponibilidade de trabalho' do
-  it 'de disponível para indisponível' do
-    user = create(:user)
+  context 'de disponível para indisponível' do
+    it 'com sucesso' do
+      user = create(:user)
 
-    login_as user
-    visit profile_path(user.profile)
-    click_on 'Não estou disponível para trabalho'
+      login_as user
+      visit profile_path(user.profile)
+      click_on 'Não estou disponível para trabalho'
 
-    expect(page).to have_current_path profile_path(user.profile)
-    expect(page).to have_content 'Alteração salva com sucesso'
-    expect(page).not_to have_button 'Não estou disponível para trabalho'
-    expect(page).to have_content 'Indisponível para trabalho'
+      expect(page).to have_current_path profile_path(user.profile)
+      expect(page).to have_content 'Alteração salva com sucesso'
+      expect(page).not_to have_button 'Não estou disponível para trabalho'
+      expect(page).to have_content 'Indisponível para trabalho'
+    end
+
+    it 'apenas do seu próprio perfil' do
+      user_a = create(:user)
+      user_b = create(:user)
+
+      login_as user_b
+      visit profile_path(user_a.profile)
+
+      expect(page).to have_content 'Disponível para trabalho'
+      expect(page).not_to have_button 'Não estou disponível para trabalho'
+    end
   end
 
-  it 'de indisponível para disponível' do
-    user = create(:user)
-    user.profile.unavailable!
+  context 'de indisponível para disponível' do
+    it 'com sucesso' do
+      user = create(:user)
+      user.profile.unavailable!
 
-    login_as user
-    visit profile_path(user.profile)
-    click_on 'Estou disponível para trabalho'
+      login_as user
+      visit profile_path(user.profile)
+      click_on 'Estou disponível para trabalho'
 
-    expect(page).to have_current_path profile_path(user.profile)
-    expect(page).to have_content 'Alteração salva com sucesso'
-    expect(page).not_to have_button 'Estou disponível para trabalho'
-    expect(page).to have_content 'Disponível para trabalho'
+      expect(page).to have_current_path profile_path(user.profile)
+      expect(page).to have_content 'Alteração salva com sucesso'
+      expect(page).not_to have_button 'Estou disponível para trabalho'
+      expect(page).to have_content 'Disponível para trabalho'
+    end
+
+    it 'apenas do seu próprio perfil' do
+      user_a = create(:user)
+      user_b = create(:user)
+      user_a.profile.unavailable!
+
+      login_as user_b
+      visit profile_path(user_a.profile)
+
+      expect(page).to have_content 'Indisponível para trabalho'
+      expect(page).not_to have_button 'Estou disponível para trabalho'
+    end
   end
 end

--- a/spec/system/profiles/user_changes_work_status_spec.rb
+++ b/spec/system/profiles/user_changes_work_status_spec.rb
@@ -1,0 +1,30 @@
+require 'rails_helper'
+
+describe 'Usuário altera o status de disponibilidade de trabalho' do
+  it 'de disponível para indisponível' do
+    user = create(:user)
+
+    login_as user
+    visit profile_path(user.profile)
+    click_on 'Não estou disponível para trabalho'
+
+    expect(page).to have_current_path profile_path(user.profile)
+    expect(page).to have_content 'Alteração salva com sucesso'
+    expect(page).not_to have_button 'Não estou disponível para trabalho'
+    expect(page).to have_content 'Indisponível para trabalho'
+  end
+
+  it 'de indisponível para disponível' do
+    user = create(:user)
+    user.profile.unavailable!
+
+    login_as user
+    visit profile_path(user.profile)
+    click_on 'Estou disponível para trabalho'
+
+    expect(page).to have_current_path profile_path(user.profile)
+    expect(page).to have_content 'Alteração salva com sucesso'
+    expect(page).not_to have_button 'Estou disponível para trabalho'
+    expect(page).to have_content 'Disponível para trabalho'
+  end
+end

--- a/spec/system/profiles/user_changes_work_status_spec.rb
+++ b/spec/system/profiles/user_changes_work_status_spec.rb
@@ -12,7 +12,7 @@ describe 'Usuário altera o status de disponibilidade de trabalho' do
       expect(page).to have_current_path profile_path(user.profile)
       expect(page).to have_content 'Alteração salva com sucesso'
       expect(page).not_to have_button 'Não estou disponível para trabalho'
-      expect(page).to have_content 'Indisponível para trabalho'
+      expect(page).to have_content 'Indisponível Para Trabalho'
     end
 
     it 'apenas do seu próprio perfil' do
@@ -22,7 +22,7 @@ describe 'Usuário altera o status de disponibilidade de trabalho' do
       login_as user_b
       visit profile_path(user_a.profile)
 
-      expect(page).to have_content 'Disponível para trabalho'
+      expect(page).to have_content 'Disponível Para Trabalho'
       expect(page).not_to have_button 'Não estou disponível para trabalho'
     end
   end
@@ -39,7 +39,7 @@ describe 'Usuário altera o status de disponibilidade de trabalho' do
       expect(page).to have_current_path profile_path(user.profile)
       expect(page).to have_content 'Alteração salva com sucesso'
       expect(page).not_to have_button 'Estou disponível para trabalho'
-      expect(page).to have_content 'Disponível para trabalho'
+      expect(page).to have_content 'Disponível Para Trabalho'
     end
 
     it 'apenas do seu próprio perfil' do
@@ -50,7 +50,7 @@ describe 'Usuário altera o status de disponibilidade de trabalho' do
       login_as user_b
       visit profile_path(user_a.profile)
 
-      expect(page).to have_content 'Indisponível para trabalho'
+      expect(page).to have_content 'Indisponível Para Trabalho'
       expect(page).not_to have_button 'Estou disponível para trabalho'
     end
   end


### PR DESCRIPTION
Essa PR aborda e resolve #53 e resolve #58

### User stories

Como usuário do Portfoliorrr, quero sinalizar à recrutadores que estou disponível ou não para novos trabalhos, para receber convites de trabalho enquanto estiver disponível e não receber convites se não estiver procurando por uma nova oportunidade.

### Critérios de aceite
- [x] Atributo no perfil do usuário específico para sinalizar se está disponível para trabalho;
  - [x] O atributo é um enum com valor padrão de `open_to_work`
- [x] A classe `Profile` deve ter um método `#open_to_work` que filtra os usuários disponíveis para trabalho;
- [x] Se estiver disponível para trabalho, o perfil do usuário deve ter um botão para mudar o status para "indisponível"

![image](https://github.com/TreinaDev/td11-portfoliorrr/assets/111306649/85d9befb-31e7-4325-8cfa-ef27820963b0)

- [x] Se estiver indisponível para trabalho, o perfil do usuário deve ter um botão para mudar o status para "disponível"

![image](https://github.com/TreinaDev/td11-portfoliorrr/assets/111306649/e45e96a4-930d-425f-932b-5cb945a9c915)

- [x] Apenas o próprio usuário pode visualizar o botão para alterar o status de trabalho

![image](https://github.com/TreinaDev/td11-portfoliorrr/assets/111306649/9b235b9e-ca91-47b6-90a0-f9f4e7ef40a2)

- [x] A rota de alteração de status de trabalho não depende do id do usuário, sempre atrelando a ação ao usuário autenticado;  
- [x] O endpoint de pesquisa de usuários por categorias de trabalho deve retornar apenas usuários disponíveis para trabalho

### Débitos
- Adicionar novos status de trabalho ao perfil (ex: `hiring`)