### PR TITLE
[Fix] Foto de perfil padrão

### DIFF
--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -17,7 +17,6 @@ class ProfilesController < ApplicationController
 
   def remove_photo
     @profile.photo.destroy!
-    @profile.set_default_photo
     redirect_to profile_path(@profile), notice: t('.success')
   end
 

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -25,10 +25,10 @@ class Profile < ApplicationRecord
   accepts_nested_attributes_for :education_infos
 
   after_create :create_personal_info!
-  after_create :set_default_photo
 
-  validate :valid_photo_content_type
-  validate :photo_size_lower_than_3mb
+  validate :valid_photo_content_type, on: :update
+  validate :photo_size_lower_than_3mb, on: :update
+
   enum work_status: { unavailable: 0, open_to_work: 10 }
   enum privacy: { private_profile: 0, public_profile: 10 }
 
@@ -83,24 +83,18 @@ class Profile < ApplicationRecord
       .limit(limit)
   end
 
-  def set_default_photo
-    photo.attach(Rails.root.join('app/assets/images/default_portfoliorrr_photo.png'))
-  end
-
   private
 
   def valid_photo_content_type
-    return if photo.blank?
-    return if photo.content_type.in?(%w[image/jpg image/jpeg image/png])
+    return if photo.present? && photo.content_type.in?(%w[image/jpg image/jpeg image/png])
 
-    errors.add(:photo, message: 'deve ser do formato .jpg, .jpeg ou .png')
+    errors.add(:photo, message: 'deve ser do formato .jpg, .jpeg ou .png') if photo.present?
   end
 
   def photo_size_lower_than_3mb
-    return if photo.blank?
-    return if photo.byte_size <= 3.megabytes
+    return if photo.present? && photo.byte_size <= 3.megabytes
 
-    errors.add(:photo, message: 'deve ter no máximo 3MB')
+    errors.add(:photo, message: 'deve ter no máximo 3MB') if photo.present?
   end
 end
 

--- a/app/views/connections/_connection_cards.html.erb
+++ b/app/views/connections/_connection_cards.html.erb
@@ -1,7 +1,11 @@
 <%= link_to connection_profile, class: 'card text-decoration-none py-2 shadow-lg rounded follower-card bg-light-subtle' do %>
   <div class="card-body row justify-content-center align-items-center">
     <div class="col-md-3 col-sm-3 profile-image">
-      <%= image_tag connection_profile.photo_attachment, width: '85rem', alt: 'Foto de perfil', class: 'rounded rounded-circle px-2' if connection_profile.photo.present? %>
+      <% if connection_profile.photo.present? %>
+        <%= image_tag connection_profile.photo_attachment, width: '85rem', alt: 'Foto de perfil', class: 'rounded rounded-circle px-2' %>
+      <% else %>
+        <%= image_tag 'default_portfoliorrr_photo.png', width: '85rem', alt: 'Foto de perfil', class: 'rounded rounded-circle px-2' %>
+      <% end %>
     </div>
     <div class="col-md-6">
       <h5 class="card-title text-primary text-decoration-underline"><%= connection_profile.full_name %></h5>

--- a/app/views/profiles/_profile_photo.html.erb
+++ b/app/views/profiles/_profile_photo.html.erb
@@ -1,0 +1,5 @@
+<% if @profile.photo.present? && @profile.valid? %>
+  <%= image_tag @profile.photo, alt: 'Foto de perfil', class: 'img-cover' %>
+<% else %>
+  <%= image_tag 'default_portfoliorrr_photo.png', alt: 'Foto de perfil', class: 'img-cover' %>
+<% end %>

--- a/app/views/profiles/edit.html.erb
+++ b/app/views/profiles/edit.html.erb
@@ -10,11 +10,7 @@
   <h2>Alterar foto de perfil</h2>
   <div class="d-flex gap-4 align-items-center w-75 justify-content-center">
     <div id="photo-preview" class="ratio ratio-1x1 rounded-circle overflow-hidden w-25">
-      <% if @profile.photo.present? && @profile.valid? %>
-        <%= image_tag @profile.photo, alt: 'Foto de perfil', class: 'img-cover' %>
-      <% else %>
-        <%= image_tag 'default_portfoliorrr_photo.png', alt: 'Foto de perfil', class: 'img-cover' %>
-      <% end %>
+      <%= render 'profile_photo' %>
     </div>
     <div id="photo-form">
       <%= form_with model: @profile do |f| %>

--- a/app/views/profiles/edit.html.erb
+++ b/app/views/profiles/edit.html.erb
@@ -10,7 +10,11 @@
   <h2>Alterar foto de perfil</h2>
   <div class="d-flex gap-4 align-items-center w-75 justify-content-center">
     <div id="photo-preview" class="ratio ratio-1x1 rounded-circle overflow-hidden w-25">
-      <%= image_tag @profile.photo_attachment, alt: 'Foto de perfil', class: 'img-cover' if @profile.photo.present? %>
+      <% if @profile.photo.present? && @profile.valid? %>
+        <%= image_tag @profile.photo, alt: 'Foto de perfil', class: 'img-cover' %>
+      <% else %>
+        <%= image_tag 'default_portfoliorrr_photo.png', alt: 'Foto de perfil', class: 'img-cover' %>
+      <% end %>
     </div>
     <div id="photo-form">
       <%= form_with model: @profile do |f| %>

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -27,11 +27,7 @@
     <aside class="px-5">
       <section class="text-center d-flex flex-column align-items-center">
         <div class="ratio ratio-1x1 rounded-circle overflow-hidden w-25">
-          <% if @profile.photo.present? && @profile.valid? %>
-            <%= image_tag @profile.photo, alt: 'Foto de perfil', class: 'img-cover' %>
-          <% else %>
-            <%= image_tag 'default_portfoliorrr_photo.png', alt: 'Foto de perfil', class: 'img-cover' %>
-          <% end %>
+          <%= render 'profile_photo' %>
         </div>
 
         <%= link_to 'Alterar foto', edit_profile_path(@profile), class: 'badge bg-secondary' if current_user == @profile.user %>

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -27,7 +27,11 @@
     <aside class="px-5">
       <section class="text-center d-flex flex-column align-items-center">
         <div class="ratio ratio-1x1 rounded-circle overflow-hidden w-25">
-          <%= image_tag @profile.photo_attachment, alt: 'Foto de perfil', class: 'img-cover' if @profile.photo.present? %>
+          <% if @profile.photo.present? && @profile.valid? %>
+            <%= image_tag @profile.photo, alt: 'Foto de perfil', class: 'img-cover' %>
+          <% else %>
+            <%= image_tag 'default_portfoliorrr_photo.png', alt: 'Foto de perfil', class: 'img-cover' %>
+          <% end %>
         </div>
 
         <%= link_to 'Alterar foto', edit_profile_path(@profile), class: 'badge bg-secondary' if current_user == @profile.user %>

--- a/app/views/searches/index.html.erb
+++ b/app/views/searches/index.html.erb
@@ -7,7 +7,11 @@
       <%= link_to profile, class: "search-result card text-decoration-none py-2 px-5 rounded follower-card bg-light-subtle mt-3 w-50" do %>
         <div class="card-body row justify-content-center align-items-center">
           <div class="col-md-4 col-sm-3 profile-image">
-            <%= image_tag profile.photo_attachment, width: '100rem', alt: 'Foto de perfil', class: 'rounded rounded-circle px-2' if profile.photo.present? %>
+            <% if profile.photo.present? %>
+              <%= image_tag profile.photo_attachment, width: '100rem', alt: 'Foto de perfil', class: 'rounded rounded-circle px-2' %>
+            <% else %>
+              <%= image_tag 'default_portfoliorrr_photo.png', width: '100rem', alt: 'Foto de perfil', class: 'rounded rounded-circle px-2' %>
+            <% end %>
           </div>
           <div class="col-md-8">
             <h3 class="card-title text-primary text-decoration-underline text-center"><%= profile.full_name %></h3>

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -147,7 +147,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_02_05_212125) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "pin", default: 0
-    t.datetime "edited_at", default: "2024-02-06 13:49:54"
+    t.datetime "edited_at", default: "2024-02-06 14:42:19"
     t.integer "status", default: 0
     t.index ["user_id"], name: "index_posts_on_user_id"
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -147,7 +147,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_02_05_212125) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "pin", default: 0
-    t.datetime "edited_at", default: "2024-02-05 22:36:46"
+    t.datetime "edited_at", default: "2024-02-06 13:49:54"
     t.integer "status", default: 0
     t.index ["user_id"], name: "index_posts_on_user_id"
   end

--- a/spec/system/profile_photo/profile_shows_user_photo_spec.rb
+++ b/spec/system/profile_photo/profile_shows_user_photo_spec.rb
@@ -10,7 +10,7 @@ describe 'Perfil mostra foto do usuário' do
       visit profile_path(user_a.profile)
 
       expect(page).to have_content user_a.full_name
-      expect(page).to have_css('img[src*="default_portfoliorrr_photo.png"]')
+      expect(page).to have_css('img[src^="/assets/default_portfoliorrr_photo"]')
     end
   end
 

--- a/spec/system/profile_photo/user_edits_profile_photo_spec.rb
+++ b/spec/system/profile_photo/user_edits_profile_photo_spec.rb
@@ -15,7 +15,7 @@ describe 'Usuário altera foto de perfil' do
     expect(page).to have_current_path profile_path(user.profile)
     expect(page).to have_content 'Sua foto foi alterada com sucesso'
     expect(page).to have_css('img[src*="male-photo.jpg"]')
-    expect(page).not_to have_css('img[src*="default_portfoliorrr_photo.png"]')
+    expect(page).not_to have_css('img[src^="default_portfoliorrr_photo"]')
   end
 
   it 'com sucesso substituindo uma foto previamente cadastrada, e não armazena a foto antiga' do
@@ -66,7 +66,6 @@ describe 'Usuário altera foto de perfil' do
     attach_file('Foto', file_path)
     click_on 'Salvar'
 
-    expect(user.profile.photo_attachment.filename).to eq 'default_portfoliorrr_photo.png'
     expect(page).to have_current_path edit_profile_path(user.profile)
     expect(page).to have_content 'Sua alteração não pôde ser salva'
     expect(page).to have_content 'Foto deve ser do formato .jpg, .jpeg ou .png'
@@ -81,7 +80,6 @@ describe 'Usuário altera foto de perfil' do
     attach_file('Foto', file_path)
     click_on 'Salvar'
 
-    expect(user.profile.photo_attachment.filename).to eq 'default_portfoliorrr_photo.png'
     expect(page).to have_current_path edit_profile_path(user.profile)
     expect(page).to have_content 'Sua alteração não pôde ser salva'
     expect(page).to have_content 'Foto deve ter no máximo 3MB'

--- a/spec/system/profile_photo/user_removes_profile_photo_spec.rb
+++ b/spec/system/profile_photo/user_removes_profile_photo_spec.rb
@@ -11,7 +11,6 @@ describe 'Usuário remove a foto de perfil' do
     click_on 'Remover foto de perfil'
     user.reload
 
-    save_page
     expect(page).to have_current_path profile_path(user.profile)
     expect(user.profile.photo_attachment).to be_blank
     expect(page).to have_content 'Sua foto foi removida com sucesso'

--- a/spec/system/profile_photo/user_removes_profile_photo_spec.rb
+++ b/spec/system/profile_photo/user_removes_profile_photo_spec.rb
@@ -9,10 +9,13 @@ describe 'Usuário remove a foto de perfil' do
     visit profile_path(user.profile)
     click_on 'Alterar foto'
     click_on 'Remover foto de perfil'
+    user.reload
 
+    save_page
     expect(page).to have_current_path profile_path(user.profile)
+    expect(user.profile.photo_attachment).to be_blank
     expect(page).to have_content 'Sua foto foi removida com sucesso'
     expect(page).not_to have_css('img[src*="male-photo.jpg"]')
-    expect(page).to have_css('img[src*="default_portfoliorrr_photo.png"]')
+    expect(page).to have_css('img[src^="/assets/default_portfoliorrr_photo"]')
   end
 end


### PR DESCRIPTION
Essa PR aborda o bug e resolve #130 

Anteriormente, a cada perfil criado (tanto em `dev`, quanto em `test`) era adicionada uma foto de perfil padrão à `Profile`. Essas fotos adicionadas via ActiveStorage não estavam sendo removidas do banco de dados de testes após a conclusão de cada teste individual, forçando a equipe a constantemente derrubar o banco de dados e recriá-lo para remover a sujeira dos testes anteriores.

Assim, a lógica de exibição da foto de perfil padrão foi movida às views, que renderizam a foto padrão a partir de `assets` caso o usuário não possua uma foto vinculada ao seu perfil. A lógica das validações também precisou ser ajustada, uma vez que agora o usuário pode ou não ter uma foto de perfil (na lógica anterior, ele sempre tinha uma foto vinculada à seu perfil).