### PR TITLE
Atualiza busca de perfil da api

### DIFF
--- a/api_doc.md
+++ b/api_doc.md
@@ -54,62 +54,49 @@ Retorno esperado:
 ```
 </details>
 
-## 2. Buscar por usuários na plataforma Portifoliorrr através dos campos `job_category.name` e `profile_job_category.description`
+## 2. Buscar por usuários na plataforma Portifoliorrr
 
 <details>
-<summary>GET /api/v1/profiles/search?search=query</summary>
+<summary>GET /api/v1/profiles</summary>
 
 <br>
 
 ### Endpoint
 
-query: Parâmetro que recebe string a ser buscada nos campos listados no título.
+query: Parâmetro que recebe string de nome da categoria ou descrição da categoria de trabalho.
 
 ```shell
-GET /api/v1/profiles/search?search=query
+GET /api/v1/profiles/search=query
 ```
 
 Retorna uma lista com todos os usuários referentes a busca. (Status: 200)
 
 ```json
-[
-  {
-      "user_id": 1,
-      "full_name": "João CampusCode Almeida",
-      "job_categories": [
-          {
-            "title": "Web Design",
-            "description": null
-          },
-          {
-            "title": "Programador Full Stack",
-            "description": null
-          },
-          {
-            "title": "Ruby on Rails",
-            "description": null
-          }
-      ]
-  },
-  {
-      "user_id": 3,
-      "full_name": "Gabriel Campos",
-      "job_categories": [
-          {
-            "title": "Web Design",
-            "description": null
-          },
-          {
-            "title": "Ruby on Rails",
-            "description": "faço umas app daora"
-          },
-          {
-            "title": "Programador Full Stack",
-            "description": "faço umas app loka"
-          }
-      ]
-  }
-]
+{
+  "data": [{ "profile_id": 1,
+              "full_name": "João CampusCode Almeida",
+              "job_categories": [
+                                  { "name": "Web Design",
+                                    "description": null },
+                                  { "name": "Programador Full Stack",
+                                    "description": null },
+                                  { "name": "Ruby on Rails",
+                                    "description": "Especialista em Rails" }
+                                ]
+            },
+            { "profile_i": 3,
+              "full_name": "Gabriel Campos",
+              "job_categories": [
+                                  { "name": "Web Design",
+                                    "description": null },
+                                  { "name": "Ruby on Rails",
+                                    "description": "faço umas app daora" },
+                                  { "name": "Programador Full Stack",
+                                    "description": "faço umas app loka"}
+                                ]
+            }
+          ]
+}
 ```
 
 Retorno esperado caso a busca não retorne resultados. (Status: 200):
@@ -130,9 +117,9 @@ Retorno esperado:
 }
 ```
 
-Erro para query de busca vazia (Status: 400)
+Resultados para query de busca vazia (Status: 200)
 
-Este erro acontece quando a busca é feita sem informar o parâmetro obrigatório query. Exemplos de buscas que retornarão este erro:
+Quando a busca é feita sem informar o parâmetro query. Retorna todos os usuários disponíveis para trabalhos. Exemplo de resposta para requisição sem query:
 
 ```shell
 GET /api/v1/profiles/search?search=
@@ -144,7 +131,39 @@ Retorno esperado:
 
 ```json
 {
-"error": "É necessário fornecer um parâmetro de busca"
+  "data": [{ "profile_id": 1,
+            "full_name": "João CampusCode Almeida",
+            "job_categories": [
+                                { "name": "Web Design",
+                                  "description": null },
+                                { "name": "Programador Full Stack",
+                                  "description": null },
+                                { "name": "Ruby on Rails",
+                                  "description": "Especialista em Rails" }
+                              ]
+            },
+            { "profile_id": 2,
+              "full_name": "Maria CampusCode Almeida",
+              "job_categories": [ { "name": "Web Design",
+                                    "description": null },
+                                  { "name": "Programador Full Stack",
+                                    "description": null },
+                                  { "name": "Ruby on Rails", 
+                                    "description": "Especialista em Rails" } 
+                                ] 
+            },
+            { "profile_id": 3,
+              "full_name": "Gabriel Campos",
+              "job_categories": [
+                                  { "name": "Web Design",
+                                    "description": null },
+                                  { "name": "Ruby on Rails",
+                                    "description": "faço umas app daora" },
+                                  { "name": "Programador Full Stack",
+                                    "description": "faço umas app loka" }
+                                ]
+            }
+          ]
 }
 ```
 </details>
@@ -168,14 +187,14 @@ Corpo da requisição:
 ```json
 {
   "invitation": {
-    "profile_id": 3,
-    "project_title": "Projeto Cola?Bora!",
-    "project_description": "Projeto Legal",
-    "project_category": "Tecnologia",
-    "colabora_invitation_id": 1,
-    "message": "Venha participar do meu projeto!",
-    "expiration_date": "2021-12-31"
-  }
+                  "profile_id": 3,
+                  "project_title": "Projeto Cola?Bora!",
+                  "project_description": "Projeto Legal",
+                  "project_category": "Tecnologia",
+                  "colabora_invitation_id": 1,
+                  "message": "Venha participar do meu projeto!",
+                  "expiration_date": "2021-12-31"
+                }
 }
 ```
 
@@ -184,8 +203,8 @@ Retorno esperado caso a requisição seja bem sucedida. (Status: 201)
 ```json
 {
   "data": {
-    "invitation_id": 1
-  }
+            "invitation_id": 1
+          }
 }
 ```
 
@@ -212,9 +231,9 @@ id de usuário inválido
 ```json
 {
   "invitation": {
-    "profile_id": 999999999999999,
-      etc...
-  }
+                  "profile_id": 999999999999999,
+                  etc...
+                }
 }
 ```
 
@@ -238,8 +257,8 @@ Corpo da requisição:
 ```json
 {
   "invitation": {
-    "status": "accepted"
-  }
+                  "status": "accepted"
+                }
 }
 ```
 
@@ -268,8 +287,8 @@ Outro exemplo de requisição que retornará este erro:
 ```json
 {
   "invitation": {
-    "status": "XXXinvalid_statusXXX"
-  }
+                  "status": "XXXinvalid_statusXXX"
+                }
 }
 ```
 
@@ -311,49 +330,37 @@ Retorno esperado caso a requisição seja bem sucedida. (Status: 200)
 
 {
   "data": {
-    "profile_id": 1,
-    "email": "joao@almeida.com",
-    "full_name": "João CampusCode Almeida",
-    "cover_letter": "Sou profissional organizado, esforçado e apaixonado pelo que faço",
-    "professional_infos": [
-      {
-        "company": "Campus Code",
-        "position": "Dev",
-        "start_date": "2022-12-12",
-        "end_date": "2023-12-12",
-        "description": "Muito código",
-        "current_job": false
-      }
-    ],
-    "education_infos": [
-      {
-        "institution": "Senai",
-        "course": "Web dev full stack",
-        "start_date": "2022-12-12",
-        "end_date": "2023-12-12"
-      },
-      {
-        "institution": "Senai",
-        "course": "Web dev full stack",
-        "start_date": "2022-12-12",
-        "end_date": "2023-12-12"
-      }
-    ],
-    "job_categories": [
-      {
-        "name": "Web Design",
-        "description": "Eu uso o Paint."
-      },
-      {
-        "name": "Programador Full Stack",
-        "description": "Prefiro Tailwind."
-      },
-      {
-        "name": "Ruby on Rails",
-        "description": "Eu amo Rails."
-      }
-    ]
-  }
+            "profile_id": 1,
+            "email": "joao@almeida.com",
+            "full_name": "João CampusCode Almeida",
+            "cover_letter": "Sou profissional organizado, esforçado e apaixonado pelo que faço",
+            "professional_infos": [
+                                    { "company": "Campus Code",
+                                      "position": "Dev",
+                                      "start_date": "2022-12-12",
+                                      "end_date": "2023-12-12",
+                                      "description": "Muito código",
+                                      "current_job": false }
+                                  ],
+            "education_infos": [
+                                  { "institution": "Senai",
+                                    "course": "Web dev full stack",
+                                    "start_date": "2022-12-12",
+                                    "end_date": "2023-12-12" },
+                                  { "institution": "Senai",
+                                    "course": "Web dev full stack",
+                                    "start_date": "2022-12-12",
+                                    "end_date": "2023-12-12" }
+                                ],
+            "job_categories": [
+                                  { "name": "Web Design",
+                                    "description": "Eu uso o Paint." },
+                                  { "name": "Programador Full Stack",
+                                    "description": "Prefiro Tailwind." },
+                                  { "name": "Ruby on Rails",
+                                    "description": "Eu amo Rails." }
+                              ]
+          }
 }
 ```
 

--- a/app/controllers/api/v1/profiles_controller.rb
+++ b/app/controllers/api/v1/profiles_controller.rb
@@ -1,13 +1,14 @@
 module Api
   module V1
     class ProfilesController < ApiController
-      def search
+      def index
         if params[:search].blank?
-          render status: :bad_request, json: { error: 'É necessário fornecer um parâmetro de busca' }
+          profiles = Profile.open_to_work
+          profiles = profiles.map { |profile| format_profile(profile) }
         else
           profiles = Profile.open_to_work.get_profile_job_categories_json(params[:search])
-          render status: :ok, json: profiles.as_json
         end
+        render status: :ok, json: { data: profiles }
       end
 
       def show
@@ -18,6 +19,14 @@ module Api
       end
 
       private
+
+      def format_profile(profile)
+        { profile_id: profile.id,
+          full_name: profile.full_name,
+          job_categories: profile.profile_job_categories.map do |category|
+            { name: category.job_category.name, description: category.description }
+          end }
+      end
 
       def result(profile)
         { data: {

--- a/bin/dev
+++ b/bin/dev
@@ -6,6 +6,6 @@ if gem list --no-installed --exact --silent foreman; then
 fi
 
 # Default to port 3000 if not specified
-export PORT="${PORT:-3000}"
+export PORT="${PORT:-4000}"
 
 exec foreman start -f Procfile.dev "$@"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -46,10 +46,7 @@ Rails.application.routes.draw do
     namespace :v1 do
       resources :projects, only: %i[index]
       resources :job_categories, only: %i[index]
-      resources :profiles, only: %i[show] do
-        get 'search', on: :collection
-      end
-
+      resources :profiles, only: %i[show index]
       resources :invitations, only: %i[create update]
     end
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -147,7 +147,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_02_05_212125) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "pin", default: 0
-    t.datetime "edited_at", default: "2024-02-06 18:20:44"
+    t.datetime "edited_at", default: "2024-02-06 18:54:08"
     t.integer "status", default: 0
     t.index ["user_id"], name: "index_posts_on_user_id"
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -147,7 +147,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_02_05_212125) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "pin", default: 0
-    t.datetime "edited_at", default: "2024-02-05 22:36:46"
+    t.datetime "edited_at", default: "2024-02-06 14:54:00"
     t.integer "status", default: 0
     t.index ["user_id"], name: "index_posts_on_user_id"
   end


### PR DESCRIPTION
Essa PR aborda e resolve #111 

### User story
Através do endpoint `api/v1/profiles?search=query`, posso obter usuários disponíveis para trabalho filtrados pelo parâmetro query. Caso nenhum parâmetro seja passado, obtenho uma lista com todos os usuários disponíveis para trabalho  
 
### Critérios de aceite
- Atualiza rota de busca de perfis da api
- Refatora controller de busca de perfis
- Formata perfis encontrados
- Ajusta testes
- Padroniza api_doc.md

### Débitos
Sem débitos