### PR TITLE
[ REFACTOR ] Inclui campo data no retorno da API Job Categories

### DIFF
--- a/api_doc.md
+++ b/api_doc.md
@@ -16,29 +16,33 @@ Abaixo, uma descrição dos endpoints disponíveis.
 GET /api/v1/job_categories
 ```
 
-Retorna a lista com todas as categorias de trabalho. (Status: 200)
+Retorna um JSON com atributo `data`, cujo valor é a lista com todas as categorias de trabalho. (Status: 200)
 
 ```json
-[
+{
+  "data": [
     {
-        "id": 1,
-        "name": "Web Design"
+      "id": 1,
+      "name": "Web Design"
     },
     {
-        "id": 2,
-        "name": "Programador Full Stack"
+      "id": 2,
+      "name": "Programador Full Stack"
     },
     {
-        "id": 3,
-        "name": "Ruby on Rails"
+      "id": 3,
+      "name": "Ruby on Rails"
     }
-]
+  ]
+}
 ```
 
 Retorno esperado caso não tenham categorias cadastradas. (Status: 200):
 
 ```json
-  []
+{
+  "data": []
+}
 ```
 
 ### Erros tratados

--- a/app/controllers/api/v1/job_categories_controller.rb
+++ b/app/controllers/api/v1/job_categories_controller.rb
@@ -5,9 +5,10 @@ module Api
         job_categories = JobCategory.all
 
         if job_categories.empty?
-          render status: :ok, json: []
+          render status: :ok, json: { data: [] }
         else
-          render status: :ok, json: job_categories.as_json(except: %i[created_at updated_at])
+          job_categories = job_categories.as_json(except: %i[created_at updated_at])
+          render status: :ok, json: { data: job_categories }
         end
       end
     end

--- a/spec/requests/apis/v1/job_categories_api_spec.rb
+++ b/spec/requests/apis/v1/job_categories_api_spec.rb
@@ -12,16 +12,18 @@ describe 'API categorias de trabalho' do
       expect(response.status).to eq 200
       expect(response.content_type).to include 'application/json'
       json_response = JSON.parse(response.body)
-      expect(json_response.class).to eq Array
-      expect(json_response.count).to eq 3
-      expect(json_response.first.keys).not_to include 'created_at'
-      expect(json_response.first.keys).not_to include 'updated_at'
-      expect(json_response.first['id']).to eq 1
-      expect(json_response.first['name']).to eq 'Full Stack'
-      expect(json_response.second['id']).to eq 2
-      expect(json_response.second['name']).to eq 'Web Design'
-      expect(json_response.third['id']).to eq 3
-      expect(json_response.third['name']).to eq 'Ruby on Rails'
+      expect(json_response.class).to eq Hash
+      expect(json_response.keys).to include 'data'
+      expect(json_response['data'].class).to eq Array
+      expect(json_response['data'].count).to eq 3
+      expect(json_response['data'].first.keys).not_to include 'created_at'
+      expect(json_response['data'].first.keys).not_to include 'updated_at'
+      expect(json_response['data'].first['id']).to eq 1
+      expect(json_response['data'].first['name']).to eq 'Full Stack'
+      expect(json_response['data'].second['id']).to eq 2
+      expect(json_response['data'].second['name']).to eq 'Web Design'
+      expect(json_response['data'].third['id']).to eq 3
+      expect(json_response['data'].third['name']).to eq 'Ruby on Rails'
     end
 
     it 'retorna uma array vazia caso não existam categorias cadastradas' do
@@ -30,8 +32,8 @@ describe 'API categorias de trabalho' do
       expect(response.status).to eq 200
       expect(response.content_type).to include 'application/json'
       json_response = JSON.parse(response.body)
-      expect(json_response.class).to eq Array
-      expect(json_response).to be_empty
+      expect(json_response.class).to eq Hash
+      expect(json_response['data']).to be_empty
     end
 
     it 'retorna um erro interno do servidor' do


### PR DESCRIPTION
Essa PR abrange e resolve #138

API de consumo pelo COLA?BORA! para obter as categorias de trabalho.

- [x] Incluir atributo `data` no retorno e seu valor é o que já estava retornando anteriormente.
- [x] Atualiza documentação para incluir esse campo

Endpoint : `http://localhost:4000/api/v1/job_categories`

---
Exemplo de retorno quando há categorias cadastradas:

```json
{ 
  "data": [
    {
      "id":1,
      "name":"Web Design"
    },
    {
      "id":2,
      "name":"Programador Full Stack"
    },
    {
     "id":3,
     "name":"Ruby on Rails"
    }
  ]
}
```

---

Quando não há categorias cadastradas, o atributo `data` tem um array vazio
```json
{
  "data": []
}
```

