### PR TITLE
[Refactor] Mensagem de erro de acordo com cenário na pesquisa de projetos Cola?Bora!

### DIFF
--- a/app/controllers/api/v1/api_controller.rb
+++ b/app/controllers/api/v1/api_controller.rb
@@ -5,6 +5,7 @@ module Api
       rescue_from ActiveRecord::RecordInvalid, with: :return_bad_request_error
       rescue_from ActionController::ParameterMissing, with: :return_bad_request_error
       rescue_from ActiveRecord::RecordNotFound, with: :return_not_found_error
+      rescue_from Faraday::ConnectionFailed, with: :return_service_unavailable_error
 
       private
 
@@ -21,6 +22,11 @@ module Api
       def return_not_found_error
         error_msg = 'Não encontrado'
         render status: :not_found, json: { error: error_msg }
+      end
+
+      def return_conectionn_failed
+        error_msg = 'Recurso não disponível'
+        render status: :service_unavailable, json: { error: error_msg }
       end
     end
   end

--- a/app/controllers/api/v1/api_controller.rb
+++ b/app/controllers/api/v1/api_controller.rb
@@ -24,7 +24,7 @@ module Api
         render status: :not_found, json: { error: error_msg }
       end
 
-      def return_conectionn_failed
+      def return_service_unavailable_error
         error_msg = 'Recurso não disponível'
         render status: :service_unavailable, json: { error: error_msg }
       end

--- a/app/controllers/api/v1/projects_controller.rb
+++ b/app/controllers/api/v1/projects_controller.rb
@@ -2,7 +2,7 @@ module Api
   module V1
     class ProjectsController < ApiController
       def index
-        response = Faraday.get('http://localhost:4000/api/v1/projects')
+        response = Faraday.get('http://localhost:3000/api/v1/projects')
         if response.status == 200
           projects = JSON.parse(response.body)
           render status: :ok, json: projects.as_json

--- a/app/views/projects/index.html.erb
+++ b/app/views/projects/index.html.erb
@@ -1,44 +1,63 @@
 <div class="container" id="vue-projects-app">
-  <h2 class="text-center">Lista de Projetos</h2>
+  <h2 class="text-center">Pesquisa de Projetos no Cola?Bora!</h2>
+
   <div v-if="emptyData" class="text-center">
     <p>{{ emptyData }}</p>
   </div>
+
   <div class="row" v-else>
     <div class="col-md-4 mx-auto mt-3">
       <label class="form-label visually-hidden" for="searchText">Pesquisar</label>
       <input class="form-control" v-model="searchText" type="text" name="searchText" id="searchText" placeholder="Digite sua pesquisa">
+
       <div class="d-flex gap-3 mt-3">
         <button class="btn btn-primary" v-on:click="setFilter('todos')" v-bind:class="{ 'btn-secondary': 'todos' === selectedFilter }">
           Todos
         </button>
+
         <button class="btn btn-primary" v-on:click="setFilter('title')" v-bind:class="{ 'btn-secondary': 'title' === selectedFilter }">
           Título
         </button>
+
         <button class="btn btn-primary" v-on:click="setFilter('description')" v-bind:class="{ 'btn-secondary': 'description' === selectedFilter }">
           Descrição
         </button>
+
         <button class="btn btn-primary" v-on:click="setFilter('category')" v-bind:class="{ 'btn-secondary': 'category' === selectedFilter }">
           Categoria
         </button>
       </div>
     </div>
-    <div class="mt-5 alert alert-warning text-center" v-if="filteredProjects.length === 0">
-      <h3>Não foi possível encontrar nenhum projeto.</h3>
-    </div>
+
+    <h3 v-if="errorMsg" class="mt-5 alert alert-danger text-center">
+      Não foi possível carregar os projetos. Tente mais tarde
+    </h3>
+
+    <h3 v-else-if="projects.length && filteredProjects.length === 0 && !errorMsg" class="mt-5 alert alert-warning text-center">
+      Não foi possível encontrar nenhum projeto.
+    </h3>
+
+    <h3 v-else-if="projects.length == 0 && !errorMsg" class="mt-5 alert alert-warning text-center">
+      Não há projetos cadastrados no momento.
+    </h3>
     <div v-else>
       <div class="mt-5 border-top w-50 mx-auto" v-for="project in filteredProjects" :key="project.id">
         <h3 class="mt-3">{{ project.title }}</h3>
         <p>Descrição: {{ project.description }}</p>
         <p>Categoria: {{ project.category }}</p>
+
         <button class="btn btn-primary" @click="showForm(project.id)" v-if="!invitationRequestsProjectsIds.includes(project.id)" >Solicitar Convite</button>
         <button v-else class="btn btn-warning" disabled >Convite Solicitado</button>
+
         <div v-if="showingForm && currentProjectId === project.id">
           <%= form_with(model: @invitation_request, url: invitation_request_path, method: :post, local: true) do |form| %>
             <input type="hidden" name="project_id" :value="project.id" />
+
             <p>
               <%= form.label :message, class: 'form-label' %>
               <%= form.text_area :message, class: 'form-control', placeholder: 'Escreva sua mensagem para o líder do projeto' %>
             </p>
+
             <p>
               <%= form.submit 'Enviar', class: 'btn btn-primary' %>
             </p>

--- a/spec/requests/apis/v1/searches_projects_spec.rb
+++ b/spec/requests/apis/v1/searches_projects_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+describe 'Usuário tenta pesquisar projetos Cola?Bora!' do
+  it 'mas ocorre erro na conexão' do
+    user = create(:user)
+    allow(Faraday).to receive(:get).with('http://localhost:3000/api/v1/projects').and_raise(Faraday::ConnectionFailed)
+
+    login_as user
+    get 'http://localhost:3000/api/v1/projects'
+
+    expect(response).to have_http_status :service_unavailable
+    json_response = JSON.parse(response.body)
+    expect(json_response['error']).to eq 'Recurso não disponível'
+  end
+end

--- a/spec/system/projects/user_request_project_invitation_spec.rb
+++ b/spec/system/projects/user_request_project_invitation_spec.rb
@@ -7,7 +7,7 @@ describe 'Usuário solicita convite para projetos' do
 
       fake_projects_response = double('faraday_response', status: 200, body: json_projects_data)
 
-      allow(Faraday).to receive(:get).with('http://localhost:4000/api/v1/projects').and_return(fake_projects_response)
+      allow(Faraday).to receive(:get).with('http://localhost:3000/api/v1/projects').and_return(fake_projects_response)
 
       user = create(:user)
 
@@ -32,7 +32,7 @@ assim que o sistema voltar ao normal."
 
       fake_projects_response = double('faraday_response', status: 200, body: json_projects_data)
 
-      allow(Faraday).to receive(:get).with('http://localhost:4000/api/v1/projects').and_return(fake_projects_response)
+      allow(Faraday).to receive(:get).with('http://localhost:3000/api/v1/projects').and_return(fake_projects_response)
 
       user = create(:user)
 

--- a/spec/system/projects/user_views_projects_spec.rb
+++ b/spec/system/projects/user_views_projects_spec.rb
@@ -7,7 +7,7 @@ describe 'Usuário visita página de projetos' do
 
       fake_response = double('faraday_response', status: 200, body: json_data)
 
-      allow(Faraday).to receive(:get).with('http://localhost:4000/api/v1/projects').and_return(fake_response)
+      allow(Faraday).to receive(:get).with('http://localhost:3000/api/v1/projects').and_return(fake_response)
 
       user = create(:user)
 
@@ -39,7 +39,7 @@ describe 'Usuário visita página de projetos' do
 
       fake_response = double('faraday_response', status: 200, body: json_data.to_json)
 
-      allow(Faraday).to receive(:get).with('http://localhost:4000/api/v1/projects').and_return(fake_response)
+      allow(Faraday).to receive(:get).with('http://localhost:3000/api/v1/projects').and_return(fake_response)
 
       user = create(:user)
       login_as user
@@ -186,6 +186,19 @@ describe 'Usuário visita página de projetos' do
       expect(page).to_not have_content 'Líder de Ginásio'
       expect(page).to_not have_content 'Me tornar líder do estádio de pedra.'
       expect(page).to_not have_content 'Auto Ajuda'
+    end
+
+    it 'e mostra mensagem de erro para status 500' do
+      response = { errors: ['Erro interno de servidor.'] }
+      fake_response = double('faraday_response', status: 500, body: response.to_json)
+
+      allow(Faraday).to receive(:get).with('http://localhost:3000/api/v1/projects').and_return(fake_response)
+
+      user = create(:user)
+      login_as user
+      visit projects_path
+
+      expect(page).to have_content('Não foi possível carregar os projetos. Tente mais tarde')
     end
   end
 

--- a/spec/system/projects/user_views_projects_spec.rb
+++ b/spec/system/projects/user_views_projects_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 describe 'Usuário visita página de projetos' do
   context 'quando logado' do
-    it 'e vê lista de projetos' do
+    it 'e vê projetos cadastrados no Cola?Bora!' do
       json_data = File.read(Rails.root.join('./spec/support/json/projects.json'))
 
       fake_response = double('faraday_response', status: 200, body: json_data)
@@ -19,7 +19,7 @@ describe 'Usuário visita página de projetos' do
       click_on 'Projetos'
 
       expect(page).to have_current_path projects_path
-      expect(page).to have_content('Lista de Projetos')
+      expect(page).to have_content('Pesquisa de Projetos no Cola?Bora!')
 
       expect(page).to have_content 'Padrão 1'
       expect(page).to have_content 'Descrição: Descrição de um projeto padrão para testes 1.'
@@ -45,7 +45,7 @@ describe 'Usuário visita página de projetos' do
       login_as user
       visit projects_path
 
-      expect(page).to have_content('Nenhum projeto encontrado')
+      expect(page).to have_content('Não há projetos cadastrados no momento.')
       expect(page).to_not have_field('Pesquisar por ')
       expect(page).to_not have_field('Pesquisar por Categoria')
       expect(page).to_not have_field('Pesquisar por Descrição')
@@ -56,7 +56,7 @@ describe 'Usuário visita página de projetos' do
 
       fake_response = double('faraday_response', status: 200, body: json_data)
 
-      allow(Faraday).to receive(:get).with('http://localhost:4000/api/v1/projects').and_return(fake_response)
+      allow(Faraday).to receive(:get).with('http://localhost:3000/api/v1/projects').and_return(fake_response)
 
       user = create(:user)
 
@@ -84,7 +84,7 @@ describe 'Usuário visita página de projetos' do
 
       fake_response = double('faraday_response', status: 200, body: json_data)
 
-      allow(Faraday).to receive(:get).with('http://localhost:4000/api/v1/projects').and_return(fake_response)
+      allow(Faraday).to receive(:get).with('http://localhost:3000/api/v1/projects').and_return(fake_response)
 
       user = create(:user)
       login_as user
@@ -111,7 +111,7 @@ describe 'Usuário visita página de projetos' do
 
       fake_response = double('faraday_response', status: 200, body: json_data)
 
-      allow(Faraday).to receive(:get).with('http://localhost:4000/api/v1/projects').and_return(fake_response)
+      allow(Faraday).to receive(:get).with('http://localhost:3000/api/v1/projects').and_return(fake_response)
 
       user = create(:user)
       login_as user
@@ -138,7 +138,7 @@ describe 'Usuário visita página de projetos' do
 
       fake_response = double('faraday_response', status: 200, body: json_data)
 
-      allow(Faraday).to receive(:get).with('http://localhost:4000/api/v1/projects').and_return(fake_response)
+      allow(Faraday).to receive(:get).with('http://localhost:3000/api/v1/projects').and_return(fake_response)
 
       user = create(:user)
       login_as user
@@ -165,7 +165,7 @@ describe 'Usuário visita página de projetos' do
 
       fake_response = double('faraday_response', status: 200, body: json_data)
 
-      allow(Faraday).to receive(:get).with('http://localhost:4000/api/v1/projects').and_return(fake_response)
+      allow(Faraday).to receive(:get).with('http://localhost:3000/api/v1/projects').and_return(fake_response)
 
       user = create(:user)
       login_as user
@@ -190,14 +190,25 @@ describe 'Usuário visita página de projetos' do
 
     it 'e mostra mensagem de erro para status 500' do
       response = { errors: ['Erro interno de servidor.'] }
-      fake_response = double('faraday_response', status: 500, body: response.to_json)
+      fake_response = double('faraday_response', status: :internal_server_error, body: response.to_json)
 
       allow(Faraday).to receive(:get).with('http://localhost:3000/api/v1/projects').and_return(fake_response)
 
       user = create(:user)
       login_as user
       visit projects_path
+      expect(page).to have_content('Não foi possível carregar os projetos. Tente mais tarde')
+    end
 
+    it 'e mostra mensagem de erro para falha de conexão' do
+      response = { error: 'Recurso não disponível' }
+      fake_response = double('faraday_response', status: :service_unavailable, body: response.to_json)
+
+      allow(Faraday).to receive(:get).with('http://localhost:3000/api/v1/projects').and_return(fake_response)
+
+      user = create(:user)
+      login_as user
+      visit projects_path
       expect(page).to have_content('Não foi possível carregar os projetos. Tente mais tarde')
     end
   end


### PR DESCRIPTION
Esse PR resolve #116 

Atualmente a página de pesquisa de projetos no Cola?Bora! mostra uma mensagem que deixa a entender que não existem projetos cadastrados, mesmo que tenha ocorrido erro de conexão.

Criamos mensagens diferentes para os cenários abaixo:
  - Quando não há projetos cadastrados no Cola?Bora!

![image](https://github.com/TreinaDev/td11-portfoliorrr/assets/124916478/29bb3196-93a9-4069-9a99-0b74a2a4487d)

  - Quando não há projetos com o termo procurado pelo usuário

![image](https://github.com/TreinaDev/td11-portfoliorrr/assets/124916478/18355708-fba7-4d7f-9a70-749f5c35ccc9)

  - Quando o retorno da API for status 500 ou ocorrer erro de conexão entre as duas plataformas

![image](https://github.com/TreinaDev/td11-portfoliorrr/assets/124916478/05ee6183-8f06-4bea-8fb0-167dc2bf15c1)


Além disso, corrigimos um problema que encontramos quando ocorria erro de conexão que fazia a página de pesquisa travar. O problema estava no Vue.js que deixava a requisição pendente mesmo saindo da página. Adicionamos um método para abortar a requisição ao desmontar o component Vue