### PR TITLE
Administrador visualiza denúncias

### DIFF
--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -30,9 +30,9 @@ class ReportsController < ApplicationController
 
   def set_reportable_for_new
     reportable_id = params[:reportable]
-    @reportable = Post.find_by(reportable_id) if params[:reportable_type] == 'Post'
-    @reportable = Profile.find_by(reportable_id) if params[:reportable_type] == 'Profile'
-    @reportable = Comment.find_by(reportable_id) if params[:reportable_type] == 'Comment'
+    @reportable = Post.find(reportable_id) if params[:reportable_type] == 'Post'
+    @reportable = Profile.find(reportable_id) if params[:reportable_type] == 'Profile'
+    @reportable = Comment.find(reportable_id) if params[:reportable_type] == 'Comment'
   end
 
   def set_reportable_for_create

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -3,4 +3,8 @@ class Report < ApplicationRecord
   belongs_to :reportable, polymorphic: true
 
   enum status: { pending: 0, granted: 5, not_granted: 9 }
+
+  def truncated_message
+    message.truncate(50)
+  end
 end

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -18,13 +18,13 @@
 
     <% if @post.draft? %>
       <p class="card-subtitle mb-2">
-        <time datetime="<%= @post.created_at.to_date %>">  
+        <time datetime="<%= @post.created_at.to_date %>">
           <%= date_fixer(@post) %> <%= I18n.l(@post.created_at.to_datetime, format: :long) %>
         </time>
       </p>
     <% else %>
       <p class="card-subtitle mb-2">
-        <time datetime="<%= @post.published_at ? @post.published_at.to_datetime : @post.created_at.to_datetime %>">  
+        <time datetime="<%= @post.published_at ? @post.published_at.to_datetime : @post.created_at.to_datetime %>">
           <%= date_fixer(@post) %> <%= I18n.l(@post.published_at ? @post.published_at.to_datetime : @post.created_at.to_datetime, format: :long) %>
         </time>
       </p>
@@ -34,7 +34,7 @@
         <%= t('posts.views.show.last_update', update_date: I18n.l(@post.edited_at.to_datetime, format: :long)) %>
       </time>
     </p>
-    
+
     <p class="card-subtitle mb-2 text-body-secondary tags">
       <% @post.tags.each do |tag| %>
         <%= link_to "##{tag.name}", searches_path(query: "##{tag.name}"), class: 'text-decoration-none' %>
@@ -65,7 +65,7 @@
     <%= @post.comments.count %> <%= Comment.model_name.human(count: @post.comments.count) %>
   </div>
   <% @post.comments.each do |comment| %>
-    <div class="card-body">
+    <div class="card-body comment">
       <blockquote class="blockquote mb-0">
         <p><%= comment.message %></p>
         <footer class="blockquote-footer">
@@ -87,9 +87,11 @@
           <% end %>
         </div>
 
-        <div>
-          <%= link_to t('reports.report_btn'), new_report_path(reportable: comment, reportable_type: comment.class), class: 'btn btn-dark btn-sm' %>
-        </div>
+        <% if current_user != comment.user %>
+          <div class="report-link-wrapper">
+            <%= link_to t('reports.report_btn'), new_report_path(reportable: comment, reportable_type: comment.class), class: 'btn btn-secondary btn-sm' %>
+          </div>
+        <% end %>
       </div>
     </div>
   <% end %>

--- a/app/views/profile/_profile.html.erb
+++ b/app/views/profile/_profile.html.erb
@@ -6,16 +6,16 @@
   <h5><%= profile.cover_letter %></h5><br>
 
   <% if profile.personal_info[:visibility] || user_is_owner %>
-    <h3><%= PersonalInfo.model_name.human %></h3>  
+    <h3><%= PersonalInfo.model_name.human %></h3>
     <%= render 'profile/personal_info', personal_info: personal_info, user_is_owner: user_is_owner %>
   <% end %>
 
   <%= link_to 'Editar Informações Pessoais', edit_user_profile_path, class:'btn btn-secondary' if user_is_owner %>
-  
+
   <% if profile.professional_infos.visibles_list.any? || user_is_owner %>
     <h3 class='mt-5'><%= ProfessionalInfo.model_name.human %></h3>
   <% end %>
-  
+
   <p>
     <%= link_to 'Adicionar Experiência Profissional', new_user_profile_professional_info_path, class:'btn btn-primary' if user_is_owner %>
   </p>
@@ -51,7 +51,7 @@
       <%= link_to 'Editar Experiência Profissional', edit_professional_info_path(professional_info), class:'btn btn-secondary' if user_is_owner %>
     </p>
   <% end %>
-  
+
   <% if profile.education_infos.visibles_list.any? || user_is_owner %>
     <h3 class='mt-5'><%= EducationInfo.model_name.human %></h3>
   <% end %>
@@ -61,7 +61,7 @@
   </p>
     <% profile.education_infos.each do |education_info| %>
       <% if education_info.visibility || user_is_owner %>
-        <h4>  
+        <h4>
           <%= EducationInfo.human_attribute_name(:institution) %>: <%= education_info.institution %>
         </h4>
         <ul>
@@ -87,9 +87,9 @@
     <% end %>
 </div>
 <div id='profile-job-categories'>
-  <% if profile.profile_job_categories.any? || user_is_owner %> 
+  <% if profile.profile_job_categories.any? || user_is_owner %>
     <h3><%= t('content.section_title') %></h3>
-  <% end %> 
+  <% end %>
 
   <%= link_to t('links.new_profile_job_category_path'), new_profile_job_category_path, class:'btn btn-primary' if user_is_owner %>
   <div class='mt-2'>

--- a/app/views/profiles/_profile_photo.html.erb
+++ b/app/views/profiles/_profile_photo.html.erb
@@ -1,5 +1,5 @@
-<% if @profile.photo.present? && @profile.valid? %>
-  <%= image_tag @profile.photo, alt: 'Foto de perfil', class: 'img-cover' %>
+<% if profile.photo.present? && profile.valid? %>
+  <%= image_tag profile.photo, alt: 'Foto de perfil', class: 'img-cover' %>
 <% else %>
   <%= image_tag 'default_portfoliorrr_photo.png', alt: 'Foto de perfil', class: 'img-cover' %>
 <% end %>

--- a/app/views/profiles/edit.html.erb
+++ b/app/views/profiles/edit.html.erb
@@ -10,7 +10,7 @@
   <h2>Alterar foto de perfil</h2>
   <div class="d-flex gap-4 align-items-center w-75 justify-content-center">
     <div id="photo-preview" class="ratio ratio-1x1 rounded-circle overflow-hidden w-25">
-      <%= render 'profile_photo' %>
+      <%= render partial: 'profiles/profile_photo', locals: { profile: @profile } %>
     </div>
     <div id="photo-form">
       <%= form_with model: @profile do |f| %>

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -27,7 +27,7 @@
     <aside class="px-5">
       <section class="text-center d-flex flex-column align-items-center">
         <div class="ratio ratio-1x1 rounded-circle overflow-hidden w-50">
-          <%= render 'profile_photo' %>
+          <%= render partial: 'profile_photo', locals: { profile: @profile } %>
         </div>
 
         <%= link_to 'Alterar foto', edit_profile_path(@profile), class: 'badge bg-secondary' if current_user == @profile.user %>

--- a/app/views/reports/_comment.html.erb
+++ b/app/views/reports/_comment.html.erb
@@ -1,0 +1,18 @@
+<div class="card text-dark d-flex flex-column px-5 shadow mb-4 p-3 rounded justify-content-center">
+  <blockquote class="blockquote mb-1">
+    <p><%= comment.message %></p>
+    <footer class="blockquote-footer">
+      <%= comment.user.full_name %>
+    </footer>
+  </blockquote>
+
+  <div class="btn-group">
+    <div class="me-2">
+      <%= comment.likes.count %> <%= Like.model_name.human(count: comment.likes.count) %>
+    </div>
+  </div>
+
+  <div class="card-subtitle mb-2 mt-2 text-muted">
+    <%= link_to t('reports.see_post'), post_path(comment.post) %>
+  </div>
+</div>

--- a/app/views/reports/_post.html.erb
+++ b/app/views/reports/_post.html.erb
@@ -1,4 +1,4 @@
-<div class="card text-muted">
+<div class="card text-dark d-flex flex-column px-5 shadow mb-4 p-3 rounded justify-content-center">
   <div class="card-body">
     <h2 class="card-title"><%= post.title %></h2>
     <h6 class="card-subtitle mb-2">
@@ -8,8 +8,8 @@
     <p class="card-text"><%= post.content %></p>
 
     <p class="card-subtitle mb-2">
-      <time datetime="<%= post.created_at.to_datetime %>">
-        <%= Post.human_attribute_name :created_at %> <%= I18n.l(post.created_at.to_datetime, format: :long) %>
+      <time datetime="<%= post.published_at.to_datetime %>">
+        <%= Post.human_attribute_name :published_at %> <%= I18n.l(post.published_at.to_datetime, format: :long) %>
       </time>
     </p>
     <p>

--- a/app/views/reports/_post.html.erb
+++ b/app/views/reports/_post.html.erb
@@ -1,0 +1,27 @@
+<div class="card text-muted">
+  <div class="card-body">
+    <h2 class="card-title"><%= post.title %></h2>
+    <h6 class="card-subtitle mb-2">
+      <%= t('posts.views.show.authored_by', author_name: post.user.full_name) %>
+    </h6>
+
+    <p class="card-text"><%= post.content %></p>
+
+    <p class="card-subtitle mb-2">
+      <time datetime="<%= post.created_at.to_datetime %>">
+        <%= Post.human_attribute_name :created_at %> <%= I18n.l(post.created_at.to_datetime, format: :long) %>
+      </time>
+    </p>
+    <p>
+      <time datetime="<%= post.edited_at.to_date %>">
+        <%= t('posts.views.show.last_update', update_date: I18n.l(post.edited_at.to_datetime, format: :long)) %>
+      </time>
+    </p>
+
+    <p class="card-subtitle mb-2 text-body-secondary tags">
+      <% post.tags.each do |tag| %>
+        <%= link_to "##{tag.name}", searches_path(query: "##{tag.name}"), class: 'text-decoration-none' %>
+      <% end %>
+    </p>
+  </div>
+</div>

--- a/app/views/reports/_profile.html.erb
+++ b/app/views/reports/_profile.html.erb
@@ -3,7 +3,7 @@
     <%= render partial: 'profiles/profile_photo', locals: { profile: profile } %>
   </div>
 
-  <h4><%= profile.full_name %></h4>
+  <h4><%= link_to profile.full_name, profile_path(profile) %></h4>
   <div class="d-flex gap-4 justify-content-center">
     <div class="d-flex flex-column" id="followers-count">
       <%= link_to profile_connections_path(profile), class: "text-decoration-none fs-5" do %>
@@ -40,7 +40,7 @@
     <% end %>
 
     <section>
-      <%= render partial: 'posts/listing', locals: { posts: profile.posts.last(3) } %>
+      <%= render partial: 'posts/listing', locals: { posts: profile.posts.not_draft.last(3) } %>
     </section>
   </div>
 </div>

--- a/app/views/reports/_profile.html.erb
+++ b/app/views/reports/_profile.html.erb
@@ -1,0 +1,46 @@
+<div class="d-flex flex-column align-items-center mb-5">
+  <div class="ratio ratio-1x1 rounded-circle overflow-hidden w-50">
+    <%= render partial: 'profiles/profile_photo', locals: { profile: profile } %>
+  </div>
+
+  <h4><%= profile.full_name %></h4>
+  <div class="d-flex gap-4 justify-content-center">
+    <div class="d-flex flex-column" id="followers-count">
+      <%= link_to profile_connections_path(profile), class: "text-decoration-none fs-5" do %>
+        <p><%= profile.followers_count %> <%= t(Connection.human_attribute_name(:follower_id, count: profile.followers_count ))%></p>
+      <% end %>
+    </div>
+    <div class="text-center d-flex flex-column" id="following-count">
+      <%= link_to profile_following_path(profile), class: "text-decoration-none fs-5" do %>
+        <p><%= profile.followed_count %> <%= t(Connection.human_attribute_name(:followed_profile_id))%> </p>
+      <% end %>
+    </div>
+  </div>
+  <div class="mt-2">
+    <% if profile.open_to_work? %>
+      <h6 class="text-success"><%= t Profile.human_attribute_name("work_status.#{profile.work_status}") %></h6>
+    <% else %>
+      <h6 class="text-danger"><%= t Profile.human_attribute_name("work_status.#{profile.work_status}") %></h6>
+    <% end %>
+  </div>
+  <div class="mt-3">
+    <% if profile.public_profile? %>
+      <h6 class="text-success"><%= t Profile.human_attribute_name("privacy.#{profile.privacy}") %></h6>
+    <% else %>
+      <h6 class="text-secondary"><%= t Profile.human_attribute_name("privacy.#{profile.privacy}") %></h6>
+    <% end %>
+  </div>
+</div>
+
+<div class="container d-flex flex-column">
+  <div id="publications">
+    <h2 id="post-list-title">Publicações</h2>
+    <% if profile.posts.empty? %>
+      <p> Esse perfil não tem publicações </p>
+    <% end %>
+
+    <section>
+      <%= render partial: 'posts/listing', locals: { posts: profile.posts.last(3) } %>
+    </section>
+  </div>
+</div>

--- a/app/views/reports/index.html.erb
+++ b/app/views/reports/index.html.erb
@@ -31,7 +31,7 @@
               <td><%= report.offence_type %></td>
               <td><%= report.truncated_message %></td>
               <td><%= I18n.t (report.reportable_type) %></td>
-              <td><%= link_to t('reports.action'), report_path(report), class: "btn btn-sm btn-secondary" %></td>
+              <td><%= link_to t('reports.action'), report_path(report), class: "see_more btn btn-sm btn-secondary"%></td>
             </tr>
           <% end %>
         </tbody>

--- a/app/views/reports/index.html.erb
+++ b/app/views/reports/index.html.erb
@@ -1,0 +1,41 @@
+<div class="mt-3">
+  <h1><%= Report.model_name.human(count: 2) %></h1>
+</div>
+
+<div class="nav-scroller border-bottom mb-4">
+  <nav class="d-flex nav nav-underline">
+    <%= link_to t('reports.pending'), reports_path, class: "nav-item nav-link link-body-emphasis #{'active' if params[:filter].blank? }" %>
+    <%= link_to t('reports.granted'), reports_path(params: { filter: 'granted' }), class: "nav-item nav-link link-body-emphasis #{'active' if params[:filter] == 'granted'}" %>
+    <%= link_to t('reports.not_granted'), reports_path(params: { filter: 'not_granted' }), class: "nav-item nav-link link-body-emphasis #{'active' if params[:filter] == 'not_granted'}" %>
+  </nav>
+</div>
+
+<section>
+  <div class="mb-3 mt-3" id="meeting-list">
+    <% if @reports.empty? %>
+      <p><%= t('reports.empty_state') %></p>
+    <% else %>
+      <table class="table table-hover">
+        <thead>
+          <tr>
+            <th><%= Report.human_attribute_name :offence_type %></th>
+            <th><%= Report.human_attribute_name :message %></th>
+            <th><%= Report.human_attribute_name :reportable_type %></th>
+            <th><%= t('reports.action') %></th>
+          </tr>
+        </thead>
+
+        <tbody>
+          <% @reports.each do |report| %>
+            <tr>
+              <td><%= report.offence_type %></td>
+              <td><%= report.truncated_message %></td>
+              <td><%= I18n.t (report.reportable_type) %></td>
+              <td><%= link_to t('reports.action'), report_path(report), class: "btn btn-sm btn-secondary" %></td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    <% end %>
+  </div>
+</section>

--- a/app/views/reports/show.html.erb
+++ b/app/views/reports/show.html.erb
@@ -1,0 +1,20 @@
+<div class="mt-3">
+  <h1><%= Report.model_name.human %></h1>
+</div>
+
+
+<div class="d-flex">
+  <div class="container d-flex flex-column w-50">
+    <%= render partial: 'post', locals: { post: @report.reportable } if @report.reportable.is_a? Post %>
+    <%= render partial: 'comment', locals: { comment: @report.reportable } if @report.reportable.is_a? Comment %>
+    <%= render partial: 'profile', locals: { profile: @report.reportable } if @report.reportable.is_a? Profile %>
+  </div>
+
+  <div class="container w-50 d-flex flex-column px-5 align-items-end">
+    <aside class= 'px-5'>
+      <section class="text-center d-flex flex-column align-items-center">
+        Versão Brasileria Rewbuer richerds
+      </section>
+    </aside>
+  </div>
+<div>

--- a/app/views/reports/show.html.erb
+++ b/app/views/reports/show.html.erb
@@ -1,20 +1,45 @@
-<div class="mt-3">
-  <h1><%= Report.model_name.human %></h1>
-</div>
-
-
 <div class="d-flex">
   <div class="container d-flex flex-column w-50">
-    <%= render partial: 'post', locals: { post: @report.reportable } if @report.reportable.is_a? Post %>
-    <%= render partial: 'comment', locals: { comment: @report.reportable } if @report.reportable.is_a? Comment %>
-    <%= render partial: 'profile', locals: { profile: @report.reportable } if @report.reportable.is_a? Profile %>
+    <div class="mt-3">
+      <% if @report.reportable.is_a? Post %>
+        <h1><%= Post.model_name.human %></h1>
+        <%= render partial: 'post', locals: { post: @report.reportable } %>
+      <% end %>
+
+      <% if @report.reportable.is_a? Comment %>
+        <h1><%= Comment.model_name.human %></h1>
+        <%= render partial: 'comment', locals: { comment: @report.reportable } %>
+      <% end %>
+
+      <% if @report.reportable.is_a? Profile %>
+        <h1><%= Profile.model_name.human %></h1>
+        <%= render partial: 'profile', locals: { profile: @report.reportable } %>
+      <% end %>
+    </div>
   </div>
 
-  <div class="container w-50 d-flex flex-column px-5 align-items-end">
-    <aside class= 'px-5'>
-      <section class="text-center d-flex flex-column align-items-center">
-        Versão Brasileria Rewbuer richerds
-      </section>
+  <div class="container d-flex flex-column w-50">
+    <aside>
+      <div class="mt-3">
+        <h1><%= Report.model_name.human %></h1>
+      </div>
+      <div class="card text-dark d-flex flex-column px-5 shadow mb-4 p-3 rounded justify-content-center">
+        <div class="card-body">
+
+          <h2 class="card-title"><%= @report.offence_type %></h2>
+
+          <h6 class="card-subtitle mb-2">
+            <small><%= @report.created_at.strftime(('%d/%m/%Y %H:%M')) %></small>
+          </h6>
+
+          <p class="card-text"><%= @report.message %></p>
+
+          <p class="card-subtitle mb-2 text-muted">
+            <%= I18n.t('reports.reporting_profile') %>: <%= link_to @report.profile.full_name, profile_path(@report.profile) %>
+          </p>
+        </div>
+      </div>
     </aside>
   </div>
 <div>
+

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -46,6 +46,10 @@
               <li class="dropdown-item" href="#">
                 <%= link_to 'Categorias de trabalho', job_categories_path, class: 'nav-link' %>
               </li>
+
+              <li class="dropdown-item" href="#">
+                <%= link_to 'Denúncias', reports_path, class: 'nav-link' %>
+              </li>
             <% end %>
             <li class="dropdown-item" href="#">
               <%= link_to 'Criar Nova Publicação', new_post_path, class: 'nav-link', data: { turbo: false }  %>

--- a/config/locales/posts.pt-BR.yml
+++ b/config/locales/posts.pt-BR.yml
@@ -2,8 +2,8 @@ pt-BR:
   activerecord:
     models:
       post:
-        one: Postagem
-        other: Postagens
+        one: Publicação
+        other: Publicações
     attributes:
       post:
         title: Título da Publicação

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -18,3 +18,6 @@ pt-BR:
     published: 'criada'
     draft: 'criada'
     archived: 'criada'
+  Post: Publicação
+  Comment: Comentário
+  Profile: Perfil

--- a/config/locales/reports.pt-BR.yml
+++ b/config/locales/reports.pt-BR.yml
@@ -1,14 +1,14 @@
 pt-BR:
   activerecord:
     models:
-      report: Denúncia
-
-  
+      report:
+        one: Denúncia
+        other: Denúncias
     attributes:
       report:
+        reportable_type: Conteúdo reportado
         message: Mensagem
         offence_type: Tipo de ofensa
-
   reports:
     create:
       success: Sua denúncia foi registrada
@@ -16,3 +16,8 @@ pt-BR:
     new:
       not_published_post: Essa publicação não está disponível.
     report_btn: Denunciar
+    pending: Pendente
+    granted: Deferido
+    not_granted: Indeferido
+    empty_state: Nenhuma denúncia encontrada
+    action: Ver mais

--- a/config/locales/reports.pt-BR.yml
+++ b/config/locales/reports.pt-BR.yml
@@ -21,3 +21,6 @@ pt-BR:
     not_granted: Indeferido
     empty_state: Nenhuma denúncia encontrada
     action: Ver mais
+    reporting_profile: Denunciado por
+    reported_when: Denunciado em
+    see_post: Ver publicação

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,7 +19,7 @@ Rails.application.routes.draw do
     post 'pin', on: :member
   end
 
-  resources :reports, only: %i[index new create]
+  resources :reports, only: %i[index new create show]
 
   resources :users, only: [] do
     resources :posts, shallow: true, only: %i[show edit update]

--- a/spec/factories/posts.rb
+++ b/spec/factories/posts.rb
@@ -4,5 +4,10 @@ FactoryBot.define do
     title { Faker::Lorem.paragraph }
     content { Faker::Lorem.paragraph sentence_count: 10 }
     edited_at { Time.zone.now }
+
+    trait :published do
+      published_at { Time.zone.now }
+      status { :published }
+    end
   end
 end

--- a/spec/factories/reports.rb
+++ b/spec/factories/reports.rb
@@ -1,7 +1,30 @@
 FactoryBot.define do
   factory :report do
-    message { 'Isso é discurso de ódio' }
+    profile
+
+    trait :for_profile do
+      association :reportable, factory: :profile
+    end
+
+    trait :for_post do
+      association :reportable, factory: :post
+    end
+
+    trait :for_comment do
+      association :reportable, factory: :comment
+    end
+
+    message { Faker::Lorem.paragraph }
     status { 0 }
-    offence_type { 'Discurso de ódio' }
+    offence_type {
+      [
+        'Discurso de ódio',
+        'Pornografia',
+        'Racismo',
+        'Spam',
+        'Conteúdo pertubador',
+        'Abuso/Perseguição'
+      ].sample
+     }
   end
 end

--- a/spec/factories/reports.rb
+++ b/spec/factories/reports.rb
@@ -16,7 +16,7 @@ FactoryBot.define do
 
     message { Faker::Lorem.paragraph }
     status { 0 }
-    offence_type {
+    offence_type do
       [
         'Discurso de ódio',
         'Pornografia',
@@ -25,6 +25,6 @@ FactoryBot.define do
         'Conteúdo pertubador',
         'Abuso/Perseguição'
       ].sample
-     }
+    end
   end
 end

--- a/spec/system/reports/admin_sees_report_spec.rb
+++ b/spec/system/reports/admin_sees_report_spec.rb
@@ -3,7 +3,8 @@ require 'rails_helper'
 describe 'Admin visualiza denúncia' do
   it 'de um post com sucesso' do
     admin = create(:user, :admin)
-    report = create(:report, :for_post)
+    post = create(:post, :published)
+    report = create(:report, reportable: post)
 
     login_as admin
     visit reports_path
@@ -15,9 +16,9 @@ describe 'Admin visualiza denúncia' do
     expect(page).to have_content "Criado por #{report.reportable.user.full_name}"
   end
 
-  xit 'de um comentário com sucesso' do
+  it 'de um comentário com sucesso' do
     admin = create(:user, :admin)
-    report = create(:report, :for_post)
+    report = create(:report, :for_comment)
 
     login_as admin
     visit reports_path
@@ -31,9 +32,10 @@ describe 'Admin visualiza denúncia' do
   it 'de um perfil com sucesso' do
     admin = create(:user, :admin)
     report = create(:report, :for_profile)
+    oldest_post = create(:post, user: report.reportable.user)
     post = create(:post, user: report.reportable.user)
-    other_post = create(:post, user: report.reportable.user)
     another_post = create(:post, user: report.reportable.user)
+    drafted_post = create(:post, user: report.reportable.user, status: :draft)
     newest_post = create(:post, user: report.reportable.user)
 
     login_as admin
@@ -43,9 +45,10 @@ describe 'Admin visualiza denúncia' do
     expect(page).to have_current_path report_path(report)
     expect(page).to have_content report.reportable.full_name
     expect(page).to have_content newest_post.title
-    expect(page).to have_content other_post.title
+    expect(page).to have_content post.title
     expect(page).to have_content another_post.title
-    expect(page).not_to have_content post.title
+    expect(page).not_to have_content oldest_post.title
+    expect(page).not_to have_content drafted_post.title
     expect(page).to have_content report.message
   end
 end

--- a/spec/system/reports/admin_sees_report_spec.rb
+++ b/spec/system/reports/admin_sees_report_spec.rb
@@ -4,11 +4,13 @@ describe 'Admin visualiza denúncia' do
   it 'de um post com sucesso' do
     admin = create(:user, :admin)
     post = create(:post, :published)
+    create(:report, :for_post)
     report = create(:report, reportable: post)
+    create(:report, :for_comment)
 
     login_as admin
     visit reports_path
-    click_on 'Ver mais'
+    page.all('.see_more').to_a.second.click
 
     expect(page).to have_current_path report_path(report)
     expect(page).to have_content report.reportable.title

--- a/spec/system/reports/admin_sees_report_spec.rb
+++ b/spec/system/reports/admin_sees_report_spec.rb
@@ -20,15 +20,16 @@ describe 'Admin visualiza denúncia' do
 
   it 'de um comentário com sucesso' do
     admin = create(:user, :admin)
-    report = create(:report, :for_comment)
+    create(:comment, message: 'Comentário top')
+    report = create(:report, :for_comment, message: 'Esse comentário me da gatilho')
 
     login_as admin
     visit reports_path
     click_on 'Ver mais'
 
     expect(page).to have_current_path report_path(report)
-    expect(page).to have_content report.reportable.message
-    expect(page).to have_content report.message
+    expect(page).to have_content 'Comentário top'
+    expect(page).to have_content 'Esse comentário me da gatilho'
   end
 
   it 'de um perfil com sucesso e vê as últimas 3 publicações' do

--- a/spec/system/reports/admin_sees_report_spec.rb
+++ b/spec/system/reports/admin_sees_report_spec.rb
@@ -1,0 +1,51 @@
+require 'rails_helper'
+
+describe 'Admin visualiza denúncia' do
+  it 'de um post com sucesso' do
+    admin = create(:user, :admin)
+    report = create(:report, :for_post)
+
+    login_as admin
+    visit reports_path
+    click_on 'Ver mais'
+
+    expect(page).to have_current_path report_path(report)
+    expect(page).to have_content report.reportable.title
+    expect(page).to have_content report.message
+    expect(page).to have_content "Criado por #{report.reportable.user.full_name}"
+  end
+
+  xit 'de um comentário com sucesso' do
+    admin = create(:user, :admin)
+    report = create(:report, :for_post)
+
+    login_as admin
+    visit reports_path
+    click_on 'Ver mais'
+
+    expect(page).to have_current_path report_path(report)
+    expect(page).to have_content report.reportable.message
+    expect(page).to have_content report.message
+  end
+
+  it 'de um perfil com sucesso' do
+    admin = create(:user, :admin)
+    report = create(:report, :for_profile)
+    post = create(:post, user: report.reportable.user)
+    other_post = create(:post, user: report.reportable.user)
+    another_post = create(:post, user: report.reportable.user)
+    newest_post = create(:post, user: report.reportable.user)
+
+    login_as admin
+    visit reports_path
+    click_on 'Ver mais'
+
+    expect(page).to have_current_path report_path(report)
+    expect(page).to have_content report.reportable.full_name
+    expect(page).to have_content newest_post.title
+    expect(page).to have_content other_post.title
+    expect(page).to have_content another_post.title
+    expect(page).not_to have_content post.title
+    expect(page).to have_content report.message
+  end
+end

--- a/spec/system/reports/admin_sees_report_spec.rb
+++ b/spec/system/reports/admin_sees_report_spec.rb
@@ -20,8 +20,8 @@ describe 'Admin visualiza denúncia' do
 
   it 'de um comentário com sucesso' do
     admin = create(:user, :admin)
-    create(:comment, message: 'Comentário top')
-    report = create(:report, :for_comment, message: 'Esse comentário me da gatilho')
+    comment = create(:comment, message: 'Comentário top')
+    report = create(:report, reportable: comment, message: 'Esse comentário me da gatilho')
 
     login_as admin
     visit reports_path

--- a/spec/system/reports/admin_sees_reports_listing_page_spec.rb
+++ b/spec/system/reports/admin_sees_reports_listing_page_spec.rb
@@ -1,0 +1,101 @@
+require 'rails_helper'
+
+describe 'Admin visita página de index de denúnicas' do
+  it 'e visualiza denúncias pendentes' do
+    admin = create(:user, :admin)
+    report = create(:report, :for_post, offence_type: 'Discurso de ódio')
+    other_report = create(:report, :for_comment, offence_type: 'Abuso/Perseguição')
+    another_report = create(:report, :for_profile, offence_type: 'Spam', status: :granted)
+
+    login_as admin
+    visit root_path
+    click_button class: 'dropdown-toggle'
+    click_on 'Denúncias'
+
+    expect(page).to have_content report.truncated_message
+    expect(page).to have_content 'Discurso de ódio'
+    expect(page).to have_content 'Publicação'
+    expect(page).to have_content other_report.truncated_message
+    expect(page).to have_content 'Abuso/Perseguição'
+    expect(page).to have_content 'Comentário'
+    expect(page).not_to have_content another_report.truncated_message
+    expect(page).not_to have_content 'Spam'
+    expect(page).not_to have_content 'Perfil'
+    expect(page).to have_current_path reports_path
+  end
+
+  it 'e visualiza denúncias deferidas' do
+    admin = create(:user, :admin)
+    report = create(:report, :for_post, offence_type: 'Discurso de ódio')
+    other_report = create(:report, :for_comment, offence_type: 'Abuso/Perseguição', status: :granted)
+    another_report = create(:report, :for_profile, offence_type: 'Spam')
+
+    login_as admin
+    visit root_path
+    click_button class: 'dropdown-toggle'
+    click_on 'Denúncias'
+    click_on 'Deferido'
+
+    expect(page).not_to have_content report.truncated_message
+    expect(page).not_to have_content 'Discurso de ódio'
+    expect(page).not_to have_content 'Publicação'
+    expect(page).to have_content other_report.truncated_message
+    expect(page).to have_content 'Abuso/Perseguição'
+    expect(page).to have_content 'Comentário'
+    expect(page).not_to have_content another_report.truncated_message
+    expect(page).not_to have_content 'Spam'
+    expect(page).not_to have_content 'Perfil'
+    expect(page).to have_current_path reports_path({ filter: 'granted' })
+  end
+
+  it 'e visualiza denúncias indeferidas' do
+    admin = create(:user, :admin)
+    report = create(:report, :for_post, offence_type: 'Discurso de ódio', status: :not_granted)
+    other_report = create(:report, :for_comment, offence_type: 'Abuso/Perseguição')
+    another_report = create(:report, :for_profile, offence_type: 'Spam')
+
+    login_as admin
+    visit root_path
+    click_button class: 'dropdown-toggle'
+    click_on 'Denúncias'
+    click_on 'Indeferido'
+
+    expect(page).to have_content report.truncated_message
+    expect(page).to have_content 'Discurso de ódio'
+    expect(page).to have_content 'Publicação'
+    expect(page).not_to have_content other_report.truncated_message
+    expect(page).not_to have_content 'Abuso/Perseguição'
+    expect(page).not_to have_content 'Comentário'
+    expect(page).not_to have_content another_report.truncated_message
+    expect(page).not_to have_content 'Spam'
+    expect(page).not_to have_content 'Perfil'
+    expect(page).to have_current_path reports_path({ filter: 'not_granted' })
+  end
+
+  it 'e não há denúncias disponíveis' do
+    admin = create(:user, :admin)
+
+    login_as admin
+    visit reports_path
+
+    expect(page).to have_content 'Nenhuma denúncia encontrada'
+  end
+
+  it 'e precisa estar logado' do
+    visit reports_path
+
+    expect(current_path).to eq new_user_session_path
+    expect(page).to have_content 'Para continuar, faça login ou registre-se.'
+  end
+
+  it 'e precisa ser admin' do
+    user = create(:user)
+
+    login_as user
+    visit reports_path
+
+    expect(current_path).to eq root_path
+    expect(page).to have_content 'Você não têm permissão para realizar essa ação.'
+  end
+end
+

--- a/spec/system/reports/admin_sees_reports_listing_page_spec.rb
+++ b/spec/system/reports/admin_sees_reports_listing_page_spec.rb
@@ -98,4 +98,3 @@ describe 'Admin visita página de index de denúnicas' do
     expect(page).to have_content 'Você não têm permissão para realizar essa ação.'
   end
 end
-

--- a/spec/system/reports/user_report_spec.rb
+++ b/spec/system/reports/user_report_spec.rb
@@ -3,6 +3,7 @@ require 'rails_helper'
 describe 'Usuário denuncia' do
   context 'um post' do
     it 'com sucesso' do
+      create(:post)
       post = create(:post)
       user = create(:user)
 
@@ -32,6 +33,16 @@ describe 'Usuário denuncia' do
       expect(current_path).to eq root_path
       expect(page).to have_content 'Essa publicação não está disponível.'
     end
+
+    it 'e não vê botão de report do próprio post' do
+      user = create(:user)
+      post = create(:post, user:)
+
+      login_as user
+      visit post_path(post)
+
+      expect(page).not_to have_content 'Denunciar'
+    end
   end
 
   context 'um comentário' do
@@ -58,6 +69,24 @@ describe 'Usuário denuncia' do
       expect(Report.last.status).to eq 'pending'
       expect(Report.last.profile).to eq user.profile
     end
+
+    it 'e não vê botão de report no próprio comentário' do
+      user = create(:user)
+      another_user = create(:user)
+      post = create(:post, user:)
+
+      create(:comment, user: another_user, post:)
+      create(:comment, user:, post:)
+      create(:comment, user: another_user, post:)
+
+      login_as user
+      visit post_path(post)
+
+      within '#comments' do
+        expect(page.all('.report-link-wrapper').size).to eq 2
+      end
+      expect(page.all('.comment').to_a.second).not_to have_link 'Denunciar'
+    end
   end
 
   context 'um perfil' do
@@ -79,6 +108,15 @@ describe 'Usuário denuncia' do
       expect(Report.last.reportable).to eq reported_user.profile
       expect(Report.last.status).to eq 'pending'
       expect(Report.last.profile).to eq user.profile
+    end
+
+    it 'e não vê botão de comentar no próprio perfil' do
+      user = create(:user)
+
+      login_as user
+      visit profile_path(user.profile)
+
+      expect(page).not_to have_link 'Denunciar'
     end
   end
 

--- a/spec/system/searches/user_searches_post_by_tag_spec.rb
+++ b/spec/system/searches/user_searches_post_by_tag_spec.rb
@@ -34,7 +34,7 @@ describe 'Usuário pesquisa hashtag' do
     expect(page).to have_content post.title
     expect(page).to have_content another_post.title
     expect(page).not_to have_content other_post.title
-    expect(page).to have_content '2 Postagens com: #tdd'
+    expect(page).to have_content '2 Publicações com: #tdd'
   end
 
   it 'deve ser uma busca exata' do


### PR DESCRIPTION
## Alcançado com esse PR

Resolve a issue #160 

Criamos a tela de listagem denúncias pendentes, deferidas e indeferidas da plataforma. Acessível apenas para contas de administração. Acessada pelo dropdown menu.

E a tela de detalhes da denúncia, onde é exibido também o objeto reportado, sendo uma view geral e uma coluna com esse objeto sendo gerada com um `render partial`.

Na denúncia de perfil, aparecem os 3 últimos posts que tenham sido publicados em algum momento, mesmo que depois tenham sido arquivados. Futuramente aparecerão os posts removidos também.

Implementamos também alguns testes para validar que um usuário não consegue ver o botão de reportar no próprio conteúdo.

### Prints
- Listagem de denúncias
![image](https://github.com/TreinaDev/td11-portfoliorrr/assets/105655467/10c63c47-aa69-4d9f-b946-87d142abe954)

- Denúncia de publicação
![image](https://github.com/TreinaDev/td11-portfoliorrr/assets/105655467/c17c310f-737d-4969-85cb-025f239bf94e)

- Denúncia de perfil
![image](https://github.com/TreinaDev/td11-portfoliorrr/assets/105655467/26d21ec2-8bdf-4db6-b003-039c8b720795)

- Denúncia de comentário
![image](https://github.com/TreinaDev/td11-portfoliorrr/assets/105655467/ed07207a-5d26-4d92-98a4-580ec5ce8ac2)


