### PR TITLE
Fix/Remove extensão de arquivos na listagem de posts

### DIFF
--- a/app/helpers/posts_helper.rb
+++ b/app/helpers/posts_helper.rb
@@ -8,4 +8,8 @@ module PostsHelper
       'Publicado em: '
     end
   end
+
+  def content_fixer(post)
+    post.content.to_plain_text.truncate(300, separator: ' ').gsub(/\[[^\]]+\.\w+\]/, '')
+  end
 end

--- a/app/views/posts/_listing.html.erb
+++ b/app/views/posts/_listing.html.erb
@@ -7,7 +7,7 @@
           <%= image_tag post.first_image_attached.representation(resize_to_limit: [ 1024, 300 ]), class:"img-fluid rounded mx-auto d-block mb-2"  %>
         <% end %>
         <p>
-          <%= post.content.to_plain_text.truncate(300, separator: ' ') %>
+          <%= content_fixer(post)  %>
         </p>
         <p class="card-subtitle mb-2 text-muted">Publicado por: <%= post.user.full_name %></p>
         <% if post.scheduled?%>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -11,7 +11,7 @@
     </div>
 
     <h6 class="card-subtitle mb-2">
-      <%= t('posts.views.show.authored_by', author_name: @post.user.full_name) %>
+      <%= link_to t('posts.views.show.authored_by', author_name: @post.user.full_name), @post.user.profile %>
     </h6>
 
     <p class="card-text"><%= @post.content %></p>
@@ -69,7 +69,7 @@
       <blockquote class="blockquote mb-0">
         <p><%= comment.message %></p>
         <footer class="blockquote-footer">
-          <%= comment.user.full_name %> <%= '(autor)' if comment.user == @post.user %>
+          <%= link_to comment.user.full_name, comment.user.profile %> <%= '(autor)' if comment.user == @post.user %>
         </footer>
       </blockquote>
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -158,7 +158,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_02_08_132247) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "pin", default: 0
-    t.datetime "edited_at", default: "2024-02-08 16:06:05"
+    t.datetime "edited_at", default: "2024-02-09 15:19:25"
     t.integer "status", default: 0
     t.datetime "published_at"
     t.index ["user_id"], name: "index_posts_on_user_id"

--- a/spec/system/comments/user_comments_blog_post_spec.rb
+++ b/spec/system/comments/user_comments_blog_post_spec.rb
@@ -27,7 +27,7 @@ describe 'Usuário comenta uma publicação' do
       click_on 'Comentar'
 
       within '#comments' do
-        expect(page).to have_link "#{post.user.full_name} (autor)", href: profile_path(post.user.profile)
+        expect(page).to have_content "#{post.user.full_name} (autor)"
         expect(page).to have_content 'Meu post é fenomenal, 10/10, magnum opus.'
       end
       expect(post).to be_persisted

--- a/spec/system/comments/user_comments_blog_post_spec.rb
+++ b/spec/system/comments/user_comments_blog_post_spec.rb
@@ -12,7 +12,7 @@ describe 'Usuário comenta uma publicação' do
       click_on 'Comentar'
 
       within '#comments' do
-        expect(page).to have_content 'Peter Parker'
+        expect(page).to have_link 'Peter Parker', href: profile_path(commenter.profile)
         expect(page).to have_content 'Um comentário legal'
       end
       expect(post).to be_persisted
@@ -27,7 +27,7 @@ describe 'Usuário comenta uma publicação' do
       click_on 'Comentar'
 
       within '#comments' do
-        expect(page).to have_content "#{post.user.full_name} (autor)"
+        expect(page).to have_link "#{post.user.full_name} (autor)", href: profile_path(post.user.profile)
         expect(page).to have_content 'Meu post é fenomenal, 10/10, magnum opus.'
       end
       expect(post).to be_persisted

--- a/spec/system/posts/user_views_post_list_spec.rb
+++ b/spec/system/posts/user_views_post_list_spec.rb
@@ -30,6 +30,7 @@ describe 'Usuário vê a lista de publicações' do
     visit root_path
 
     expect(page).to have_selector '#post-list', text: post.content.to_plain_text.truncate(300, separator: ' ')
+                                                          .gsub(/\[[^\]]+\.\w+\]/, '')
   end
 
   it 'e vê a data de cada publicação' do

--- a/spec/system/posts/visitor_views_post_spec.rb
+++ b/spec/system/posts/visitor_views_post_spec.rb
@@ -9,7 +9,7 @@ describe 'Visitante visualiza uma publicação' do
     expect(current_path).to eq post_path(post)
     expect(page).to have_content 'Título do post'
     expect(page).to have_content 'Conteúdo do post'
-    expect(page).to have_content "Criado por #{post.user.full_name}"
+    expect(page).to have_link "Criado por #{post.user.full_name}", href: profile_path(post.user.profile)
   end
 
   it 'e não vê arquivada' do


### PR DESCRIPTION
Esse PR aborda e resolve #163 e resolve #168

- Cria método no helper de posts para arrumar o conteúdo de posts na listagem de posts (no feed e no perfil do usuário).
- Adiciona links para perfis de usuários em posts (autor do post) e em comentários (autor do comentário).

Prints:
No perfil
![image](https://github.com/TreinaDev/td11-portfoliorrr/assets/105087841/feac78b8-c9b4-4e8f-ad22-7fad883e2ecb)
Na home
![image](https://github.com/TreinaDev/td11-portfoliorrr/assets/105087841/23d7aea0-a7fc-496c-a9bd-bb91f48b7740)
Links para perfis:
![image](https://github.com/TreinaDev/td11-portfoliorrr/assets/105087841/5da91b1a-81b4-4178-815a-dbfe42295165)
