### PR TITLE
Fix/Data de publicação se torna obrigatoria para publicação programada

### DIFF
--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -5,6 +5,7 @@ class Post < ApplicationRecord
   has_many :reports, as: :reportable, dependent: :destroy
 
   validates :title, :content, :status, presence: true
+  validates :published_at, presence: true, if: -> { scheduled? }
   validate :correct_file_type
   validate :file_size
   validate :validate_published_at

--- a/spec/requests/reports/user_reports_spec.rb
+++ b/spec/requests/reports/user_reports_spec.rb
@@ -40,7 +40,7 @@ describe 'Usuário denuncia' do
 
     it 'mas post está agendado' do
       user = create(:user)
-      post = create(:post, status: :scheduled)
+      post = create(:post, status: :scheduled, published_at: Time.current)
 
       login_as user
       post reports_path, params: {

--- a/spec/system/connections/user_views_followers_spec.rb
+++ b/spec/system/connections/user_views_followers_spec.rb
@@ -26,7 +26,7 @@ describe 'Usuário vê lista de usuários seguidos' do
       visit profile_path(follower.profile)
       click_on '3 Seguindo'
 
-      expect(current_path).to eq profile_following_path(follower.profile)
+      expect(page).to have_current_path profile_following_path(follower.profile)
       expect(page).to have_content follower.full_name
       expect(page).to have_content 'Seguindo 3 usuários'
       expect(page).not_to have_link first_followed.full_name

--- a/spec/system/posts/user_creates_post_spec.rb
+++ b/spec/system/posts/user_creates_post_spec.rb
@@ -180,8 +180,23 @@ describe 'Usuário cria uma postagem' do
 
       expect(posts.count).to eq 1
       expect(posts.first).to be_scheduled
+      expect(post_schedule_spy).to have_received(:perform_later).with(Post.last)
       expect(page).to have_content 'Publicação agendada com sucesso'
       expect(page).to have_content "Agendado para: #{I18n.l(posts.last.published_at.to_datetime, format: :long)}"
+    end
+
+    it 'com falha' do
+      user = create(:user, full_name: 'Seiya de Pégaso')
+
+      login_as user
+      visit new_post_path
+      fill_in 'Título da Publicação', with: 'Olá Mundo!'
+      fill_in_rich_text_area 'conteudo', with: 'Primeira <em>publicação</em>'
+      choose 'Agendar'
+      fill_in 'post_published_at', with: ''
+      click_on 'Salvar'
+
+      expect(page).to have_content 'Data de publicação não pode ficar em branco'
     end
   end
 end

--- a/spec/system/posts/user_creates_post_spec.rb
+++ b/spec/system/posts/user_creates_post_spec.rb
@@ -174,7 +174,7 @@ describe 'Usuário cria uma postagem' do
       fill_in 'Título da Publicação', with: 'Olá Mundo!'
       fill_in_rich_text_area 'conteudo', with: 'Primeira <em>publicação</em>'
       choose 'Agendar'
-      fill_in 'post_published_at', with: 2.days.from_now.strftime('%d/%m/%Y %H:%M')
+      fill_in 'post_published_at', with: 2.days.from_now.noon
       click_on 'Salvar'
       posts = Post.all
 

--- a/spec/system/posts/user_edits_post_spec.rb
+++ b/spec/system/posts/user_edits_post_spec.rb
@@ -150,7 +150,7 @@ describe 'Usuário edita uma publicação' do
     visit edit_post_path(post)
     fill_in 'Título da Publicação', with: 'O título mudou'
     choose 'Agendar'
-    fill_in 'post_published_at', with: 2.days.from_now.strftime('%d/%m/%Y %H:%M')
+    fill_in 'post_published_at', with: 2.days.from_now.noon
     click_on 'Salvar'
 
     post = Post.last


### PR DESCRIPTION
Essa PR resolve #176 

Antes não havia validação para data de publicação obrigatória em caso de agendamento gerando erros 

![Captura de tela 2024-02-10 151413](https://github.com/TreinaDev/td11-portfoliorrr/assets/101219858/99b6100f-7d5d-4da0-9820-ba3d476a7f11)

Essa PR corrige esse comportamento
![Captura de tela 2024-02-10 151559](https://github.com/TreinaDev/td11-portfoliorrr/assets/101219858/aaf0e9e7-d8f3-4fb0-a67a-bd72b896b995)
