### PR TITLE
[FIX] Corrige instrução errada na documentação do endpoint PATCH /api/v1/invitations/

### DIFF
--- a/api_doc.md
+++ b/api_doc.md
@@ -373,9 +373,7 @@ Corpo da requisição:
 
 ```json
 {
-  "invitation": {
-                  "status": "accepted"
-                }
+  "status": "accepted"
 }
 ```
 
@@ -403,9 +401,7 @@ Outro exemplo de requisição que retornará este erro:
 
 ```json
 {
-  "invitation": {
-                  "status": "XXXinvalid_statusXXX"
-                }
+  "status": "XXXinvalid_statusXXX"
 }
 ```
 


### PR DESCRIPTION
Essa PR aborda e resolve #192 

Na documentação de API da Portfoliorrr, no tópico ‘6. Editar status de convite’, o corpo da requisição está errado.
Correto:
```json
{
  "status": "accepted"
}
```
Na Doc esta como:
```json
{
  "invitation": {
                  "status": "accepted"
                }
}
