### PR TITLE
[Feature] Alterar status da solicitacao para accepted

### DIFF
--- a/app/jobs/accept_invitation_request_job.rb
+++ b/app/jobs/accept_invitation_request_job.rb
@@ -1,0 +1,10 @@
+class AcceptInvitationRequestJob < ApplicationJob
+  queue_as :default
+
+  def perform(invitation)
+    project_id = InvitationRequestService::ProjectIdRetriever.send(invitation)
+
+    request = InvitationRequest.pending.find_by(profile_id: invitation.profile.id, project_id:)
+    request.accepted! if request.present?
+  end
+end

--- a/app/models/invitation.rb
+++ b/app/models/invitation.rb
@@ -11,6 +11,7 @@ class Invitation < ApplicationRecord
 
   after_create :set_status
   after_create :create_notification
+  after_create :validate_pending_request
 
   def set_status
     self.status = 'pending'
@@ -30,5 +31,12 @@ class Invitation < ApplicationRecord
 
   def create_notification
     Notification.create(profile:, notifiable: self)
+  end
+
+  def validate_pending_request
+    project_id = InvitationRequestService::ProjectIdRetriever.send(self)
+
+    request = InvitationRequest.pending.find_by(profile_id:, project_id:)
+    request.accepted! if request.present?
   end
 end

--- a/app/models/invitation.rb
+++ b/app/models/invitation.rb
@@ -34,6 +34,6 @@ class Invitation < ApplicationRecord
   end
 
   def queue_pending_request_status_update
-    AcceptInvitationRequestJob.perform_later(self)
+    AcceptInvitationRequestJob.perform_later(profile_id:, colabora_invitation_id:)
   end
 end

--- a/app/models/invitation_request.rb
+++ b/app/models/invitation_request.rb
@@ -7,6 +7,10 @@ class InvitationRequest < ApplicationRecord
 
   after_create :queue_request_invitation_job
 
+  def accepted!
+    super if pending?
+  end
+
   def process_colabora_api_response(response)
     response = json_treated_response(response)
     if response.keys.first == 'data'

--- a/app/services/invitation_request_service.rb
+++ b/app/services/invitation_request_service.rb
@@ -1,5 +1,6 @@
 module InvitationRequestService
   COLABORA_PROJECTS_URL = 'http://localhost:3000/api/v1/projects'.freeze
+  COLABORA_INVITATIONS_BASE_URL = 'http://localhost:3000/api/v1/invitations'.freeze
 
   class ColaboraProject
     def self.send
@@ -34,6 +35,18 @@ module InvitationRequestService
         project = projects.find { |proj| proj.id == request.project_id }
         InvitationRequestInfo.new(invitation_request: request, project:)
       end
+    end
+  end
+
+  class ProjectIdRetriever
+    def self.send(invitation)
+      response = Faraday.get("#{COLABORA_INVITATIONS_BASE_URL}?profile_id=#{invitation.profile_id}")
+      response_json = JSON.parse(response.body, symbolize_names: true)
+
+      invitation = response_json.find do |inv|
+        inv[:invitation_id] == invitation.colabora_invitation_id
+      end
+      invitation[:project_id]
     end
   end
 end

--- a/app/services/invitation_request_service.rb
+++ b/app/services/invitation_request_service.rb
@@ -39,14 +39,15 @@ module InvitationRequestService
   end
 
   class ProjectIdRetriever
-    def self.send(invitation)
-      response = Faraday.get("#{COLABORA_INVITATIONS_BASE_URL}?profile_id=#{invitation.profile_id}")
+    def self.send(profile_id:, colabora_invitation_id:)
+      url = "#{COLABORA_INVITATIONS_BASE_URL}?profile_id=#{profile_id}"
+      response = Faraday.new { |faraday| faraday.response :raise_error }.get(url)
       response_json = JSON.parse(response.body, symbolize_names: true)
 
-      invitation = response_json.find do |inv|
-        inv[:invitation_id] == invitation.colabora_invitation_id
+      invitation_request = response_json.find do |inv|
+        inv[:invitation_id] == colabora_invitation_id
       end
-      invitation[:project_id]
+      invitation_request[:project_id]
     end
   end
 end

--- a/spec/jobs/accept_invitation_request_job_spec.rb
+++ b/spec/jobs/accept_invitation_request_job_spec.rb
@@ -18,12 +18,48 @@ RSpec.describe AcceptInvitationRequestJob, type: :job do
       }].to_json
 
       fake_response = double('faraday_response', status: 200, body: colabora_invitation_json)
-      allow(Faraday).to receive(:get).with("http://localhost:3000/api/v1/invitations?profile_id=#{user.profile.id}")
+      allow(Faraday).to receive_message_chain(:new, :get).with("http://localhost:3000/api/v1/invitations?profile_id=#{user.profile.id}")
                     .and_return(fake_response)
 
-      AcceptInvitationRequestJob.perform_now(invitation)
+      AcceptInvitationRequestJob.perform_now(
+        profile_id: user.profile.id,
+        colabora_invitation_id: invitation.colabora_invitation_id
+      )
 
       expect(invitation_request.reload).to be_accepted
+    end
+
+    it 'tenta alterar o status para "Aceita" e não consegue se conectar ao servidor' do
+      allow(Faraday).to receive_message_chain(:new, :get).and_raise(Faraday::ConnectionFailed)
+
+      user = create(:user)
+      invitation_request = create(:invitation_request, status: :pending)
+      invitation = build(:invitation, profile: user.profile, colabora_invitation_id: 1)
+
+      AcceptInvitationRequestJob.perform_now(
+        profile_id: user.profile.id,
+        colabora_invitation_id: invitation.colabora_invitation_id
+      )
+
+      expect(invitation_request.reload.status).to eq 'pending'
+    end
+
+    it 'tenta alterar o status para "aceita" 5 vezes' do
+      allow(Faraday).to receive_message_chain(:new, :get).and_raise(Faraday::ConnectionFailed)
+
+      user = create(:user)
+      invitation_request = create(:invitation_request, status: :pending)
+      invitation = build(:invitation, profile: user.profile, colabora_invitation_id: 1)
+
+      perform_enqueued_jobs do
+        AcceptInvitationRequestJob.perform_later(
+          profile_id: user.profile.id,
+          colabora_invitation_id: invitation.colabora_invitation_id
+        )
+      end
+
+      assert_performed_jobs 5
+      expect(invitation_request).to be_pending
     end
   end
 end

--- a/spec/jobs/accept_invitation_request_job_spec.rb
+++ b/spec/jobs/accept_invitation_request_job_spec.rb
@@ -1,0 +1,29 @@
+require 'rails_helper'
+
+RSpec.describe AcceptInvitationRequestJob, type: :job do
+  context '.perform' do
+    it 'altera a solicitação de convite para "Aceita" caso receba um convite do Cola?Bora!' do
+      user = create(:user)
+      invitation_request = create(:invitation_request, profile: user.profile,
+                                                       project_id: 2, status: :pending)
+
+      invitation = build(:invitation, profile: user.profile, colabora_invitation_id: 1)
+
+      colabora_invitation_json = [{
+        invitation_id: 1,
+        expiration_date: 3.days.from_now.to_date,
+        project_id: 2,
+        project_title: 'Meu primeiro projeto',
+        message: 'Venha fazer parte'
+      }].to_json
+
+      fake_response = double('faraday_response', status: 200, body: colabora_invitation_json)
+      allow(Faraday).to receive(:get).with("http://localhost:3000/api/v1/invitations?profile_id=#{user.profile.id}")
+                    .and_return(fake_response)
+
+      AcceptInvitationRequestJob.perform_now(invitation)
+
+      expect(invitation_request.reload).to be_accepted
+    end
+  end
+end

--- a/spec/models/invitation_request_spec.rb
+++ b/spec/models/invitation_request_spec.rb
@@ -18,4 +18,50 @@ RSpec.describe InvitationRequest, type: :model do
       expect(successful_request).to be_valid
     end
   end
+
+  describe '#accepted!' do
+    it 'muda o status para accepted quando o atual é pending' do
+      invitation_request = create(:invitation_request, status: :pending)
+
+      invitation_request.accepted!
+
+      expect(invitation_request.reload.status).to eq 'accepted'
+    end
+
+    it 'não muda o status para accepted quando o atual é processing' do
+      invitation_request = create(:invitation_request, status: :processing)
+
+      invitation_request.accepted!
+
+      expect(invitation_request.reload.status).not_to eq 'accepted'
+      expect(invitation_request.status).to eq 'processing'
+    end
+
+    it 'não muda o status para accepted quando o atual é refused' do
+      invitation_request = create(:invitation_request, status: :refused)
+
+      invitation_request.accepted!
+
+      expect(invitation_request.reload.status).not_to eq 'accepted'
+      expect(invitation_request.status).to eq 'refused'
+    end
+
+    it 'não muda o status para accepted quando o atual é error' do
+      invitation_request = create(:invitation_request, status: :error)
+
+      invitation_request.accepted!
+
+      expect(invitation_request.reload.status).not_to eq 'accepted'
+      expect(invitation_request.status).to eq 'error'
+    end
+
+    it 'não muda o status para accepted quando o atual é aborted' do
+      invitation_request = create(:invitation_request, status: :aborted)
+
+      invitation_request.accepted!
+
+      expect(invitation_request.reload.status).not_to eq 'accepted'
+      expect(invitation_request.status).to eq 'aborted'
+    end
+  end
 end

--- a/spec/requests/apis/v1/invitations/user_receives_invite_spec.rb
+++ b/spec/requests/apis/v1/invitations/user_receives_invite_spec.rb
@@ -31,6 +31,35 @@ describe 'API convites' do
       expect(user_profile.invitations.first.colabora_invitation_id).to eq 1
     end
 
+    it 'e altera status de solicitação pendente para aceita' do
+      user = create(:user)
+      invitation_request = create(:invitation_request, status: :pending, profile: user.profile, project_id: 1)
+      colabora_invitation_json = [{
+        invitation_id: 1,
+        expiration_date: 3.days.from_now.to_date,
+        project_id: 1,
+        project_title: 'Meu primeiro projeto',
+        message: 'Venha fazer parte'
+      }].to_json
+      fake_response = double('faraday_response', status: 200, body: colabora_invitation_json)
+      allow(Faraday).to receive(:get).with("http://localhost:3000/api/v1/invitations?profile_id=#{user.id}")
+                    .and_return(fake_response)
+
+      post '/api/v1/invitations', params: {
+        invitation: {
+          profile_id: user.id,
+          project_title: 'Projeto Cola?Bora!',
+          project_description: 'Projeto Legal',
+          project_category: 'Tecnologia',
+          colabora_invitation_id: 1,
+          message: 'Venha participar do meu projeto!',
+          expiration_date: 1.week.from_now.to_date
+        }
+      }
+
+      expect(invitation_request.reload.status).to eq 'accepted'
+    end
+
     context 'com parâmetros inválidos' do
       it 'parametros em branco' do
         post '/api/v1/invitations'

--- a/spec/services/invitation_request_service/project_id_retriever_spec.rb
+++ b/spec/services/invitation_request_service/project_id_retriever_spec.rb
@@ -1,0 +1,31 @@
+require 'rails_helper'
+
+RSpec.describe InvitationRequestService::ProjectIdRetriever do
+  context '.send' do
+    it 'retorna o ID do projeto associado a um convite' do
+      user = create(:user)
+      create(:invitation_request, profile: user.profile,
+                                  project_id: 1, status: :pending)
+      create(:invitation_request, profile: user.profile,
+                                  project_id: 2, status: :pending)
+
+      colabora_invitation_json = [{
+        invitation_id: 1,
+        expiration_date: 3.days.from_now.to_date,
+        project_id: 2,
+        project_title: 'Meu primeiro projeto',
+        message: 'Venha fazer parte'
+      }].to_json
+
+      fake_response = double('faraday_response', status: 200, body: colabora_invitation_json)
+      allow(Faraday).to receive(:get).with("http://localhost:3000/api/v1/invitations?profile_id=#{user.profile.id}")
+                    .and_return(fake_response)
+
+      invitation = create(:invitation, profile: user.profile, colabora_invitation_id: 1)
+
+      project_id = InvitationRequestService::ProjectIdRetriever.send(invitation)
+
+      expect(project_id).to eq 2
+    end
+  end
+end

--- a/spec/services/invitation_request_service/project_id_retriever_spec.rb
+++ b/spec/services/invitation_request_service/project_id_retriever_spec.rb
@@ -18,12 +18,15 @@ RSpec.describe InvitationRequestService::ProjectIdRetriever do
       }].to_json
 
       fake_response = double('faraday_response', status: 200, body: colabora_invitation_json)
-      allow(Faraday).to receive(:get).with("http://localhost:3000/api/v1/invitations?profile_id=#{user.profile.id}")
+      allow(Faraday).to receive_message_chain(:new, :get).with("http://localhost:3000/api/v1/invitations?profile_id=#{user.profile.id}")
                     .and_return(fake_response)
 
       invitation = create(:invitation, profile: user.profile, colabora_invitation_id: 1)
 
-      project_id = InvitationRequestService::ProjectIdRetriever.send(invitation)
+      project_id = InvitationRequestService::ProjectIdRetriever.send(
+        profile_id: user.profile.id,
+        colabora_invitation_id: invitation.colabora_invitation_id
+      )
 
       expect(project_id).to eq 2
     end

--- a/spec/system/invitation_requests/invitation_request_is_accepted_spec.rb
+++ b/spec/system/invitation_requests/invitation_request_is_accepted_spec.rb
@@ -22,12 +22,15 @@ describe 'Solicitação de convite é aceita' do
     }].to_json
 
     fake_invitation_list_response = double('faraday_response', status: 200, body: colabora_invitation_json)
-    allow(Faraday).to receive(:get).with("http://localhost:3000/api/v1/invitations?profile_id=#{user.profile.id}")
+    allow(Faraday).to receive_message_chain(:new, :get).with("http://localhost:3000/api/v1/invitations?profile_id=#{user.profile.id}")
                   .and_return(fake_invitation_list_response)
 
     invitation = build(:invitation, profile: user.profile, colabora_invitation_id: 1)
 
-    AcceptInvitationRequestJob.perform_now invitation
+    AcceptInvitationRequestJob.perform_now(
+      profile_id: user.profile.id,
+      colabora_invitation_id: invitation.colabora_invitation_id
+    )
 
     login_as user
     visit invitation_requests_path

--- a/spec/system/invitation_requests/invitation_request_is_accepted_spec.rb
+++ b/spec/system/invitation_requests/invitation_request_is_accepted_spec.rb
@@ -1,0 +1,44 @@
+require 'rails_helper'
+
+describe 'Solicitação de convite é aceita' do
+  it 'com sucesso' do
+    user = create(:user)
+
+    invitation_request_one = create(:invitation_request, profile: user.profile,
+                                                         project_id: 1, status: :pending)
+    invitation_request_two = create(:invitation_request, profile: user.profile,
+                                                         project_id: 2, status: :pending)
+
+    json_data = File.read(Rails.root.join('./spec/support/json/projects.json'))
+    fake_projects_response = double('faraday_response', success?: true, body: json_data)
+    allow(Faraday).to receive(:get).with('http://localhost:3000/api/v1/projects').and_return(fake_projects_response)
+
+    colabora_invitation_json = [{
+      invitation_id: 1,
+      expiration_date: 3.days.from_now.to_date,
+      project_id: 1,
+      project_title: 'Meu primeiro projeto',
+      message: 'Venha fazer parte'
+    }].to_json
+
+    fake_invitation_list_response = double('faraday_response', status: 200, body: colabora_invitation_json)
+    allow(Faraday).to receive(:get).with("http://localhost:3000/api/v1/invitations?profile_id=#{user.profile.id}")
+                  .and_return(fake_invitation_list_response)
+
+    create(:invitation, profile: user.profile, colabora_invitation_id: 1)
+
+    login_as user
+    visit invitation_requests_path
+
+    expect(invitation_request_one.reload).to be_accepted
+    expect(invitation_request_two.reload).to be_pending
+
+    within "#request_#{invitation_request_one.id}" do
+      expect(page).to have_content 'Aceita'
+    end
+
+    within "#request_#{invitation_request_two.id}" do
+      expect(page).to have_content 'Pendente'
+    end
+  end
+end

--- a/spec/system/invitation_requests/invitation_request_is_accepted_spec.rb
+++ b/spec/system/invitation_requests/invitation_request_is_accepted_spec.rb
@@ -25,7 +25,9 @@ describe 'Solicitação de convite é aceita' do
     allow(Faraday).to receive(:get).with("http://localhost:3000/api/v1/invitations?profile_id=#{user.profile.id}")
                   .and_return(fake_invitation_list_response)
 
-    create(:invitation, profile: user.profile, colabora_invitation_id: 1)
+    invitation = build(:invitation, profile: user.profile, colabora_invitation_id: 1)
+
+    AcceptInvitationRequestJob.perform_now invitation
 
     login_as user
     visit invitation_requests_path


### PR DESCRIPTION
Esse PR resolve #199

Quando o líder de projeto aprova uma solicitação de participação, o Cola?Bora! enviará para nós apenas um novo convite, a atualização do status da solicitação é tratada no Portfoliorrr na hora da criação do convite.

No model de `invitation`, existe um callback `after_create` que enfileira um job que valida se existe um `invitation_request` com status `pending`; se existir, o status da solicitação deve ser alterado para `accepted`

https://github.com/TreinaDev/td11-portfoliorrr/blob/a7a73fa90ffdda01568415c66f4c2ffb724bfa53/app/models/invitation.rb#L14
https://github.com/TreinaDev/td11-portfoliorrr/blob/a7a73fa90ffdda01568415c66f4c2ffb724bfa53/app/jobs/accept_invitation_request_job.rb#L8

## Fluxo:

Ao recebermos um convite por parte do Cola?Bora!, através de um POST na nossa API, criamos uma instância de Invitation no nosso banco de dados. Ao criarmos essa instância, automaticamente é alterado o status da nossa solicitação de convite para `Aceita`. Para isso acontecer, assim que é criada o convite no nosso banco de dados, temos de fazer uma requisição no endpoint deles: `GET api/v1/invitations?profile_id=1`, passando o id do nosso usuário. Esse endpoint retornará uma lista de convites para esse usuário registradas no banco de dados do Cola?Bora!

De posse dessa lista de convites, fazemos uma busca pelo que possui o atributo `invitation_id` igual ao `colabora_invitation_id` do convite recebido.

Após filtrarmos a lista de convites, pegamos o `project_id` desse convite e fazemos uma busca na lista de solicitações de convite desse usuário no nosso banco de dados. Ao encontrarmos essa solicitação, verificamos se ela está como status `Pendente`, e, se sim, alteramos-la para `Aceita`.