### PR TITLE
Remoção de default value

### DIFF
--- a/db/migrate/20240126133553_add_edited_at_to_posts.rb
+++ b/db/migrate/20240126133553_add_edited_at_to_posts.rb
@@ -1,5 +1,5 @@
 class AddEditedAtToPosts < ActiveRecord::Migration[7.1]
   def change
-    add_column :posts, :edited_at, :datetime, default: Time.zone.now
+    add_column :posts, :edited_at, :datetime
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -55,8 +55,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_02_12_195603) do
     t.integer "user_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.text "old_message"
     t.integer "status", default: 0
+    t.text "old_message"
     t.index ["post_id"], name: "index_comments_on_post_id"
     t.index ["user_id"], name: "index_comments_on_user_id"
   end
@@ -161,7 +161,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_02_12_195603) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "pin", default: 0
-    t.datetime "edited_at", default: "2024-02-13 03:11:57"
+    t.datetime "edited_at"
     t.integer "status", default: 0
     t.datetime "published_at"
     t.string "old_status"


### PR DESCRIPTION
Alterada a migration 20240126133553_add_edited_at_to_posts.rb

A migration acrescentava default: Time.zone.now na coluna edited_at de posts, causando o schema a gerar conflito sempre que se faz migrate. O motivo da mudança anterior já foi contornado de outra forma.