### PR TITLE
[Setup] Configura MailCatcher e Procfile.dev

### DIFF
--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,3 +1,4 @@
 web: env RUBY_DEBUG_OPEN=true bin/rails server
 js: yarn build --watch
 css: yarn watch:css
+job: bundle exec rake solid_queue:start

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ O Portfoliorrr é uma rede social com funcionalidades de portfólio para pessoas
 
 - [Informações técnicas](https://github.com/TreinaDev/td11-portfoliorrr?tab=readme-ov-file#informa%C3%A7%C3%B5es-t%C3%A9cnicas)
 - [Como configurar a aplicação](https://github.com/TreinaDev/td11-portfoliorrr?tab=readme-ov-file#como-configurar-a-aplica%C3%A7%C3%A3o)
+- [Ver emails enviados em ambiente de desenvolvimento](https://github.com/TreinaDev/td11-portfoliorrr?tab=readme-ov-file#ver-emails-enviados-em-ambiente-de-desenvolvimento)
 - [Como visualizar a aplicação no navegador](https://github.com/TreinaDev/td11-portfoliorrr?tab=readme-ov-file#como-visualizar-a-aplica%C3%A7%C3%A3o-no-navegador)
 - [Documentação da API](https://github.com/TreinaDev/td11-portfoliorrr?tab=readme-ov-file#documenta%C3%A7%C3%A3o-da-api)
 
@@ -26,6 +27,19 @@ O Portfoliorrr é uma rede social com funcionalidades de portfólio para pessoas
 - Siga as instruções de configuração da aplicação
 - Rode o comando `bin/dev`;
 - Acesse a aplicação através do endereço `http://localhost:4000/`
+
+## Ver emails enviados em ambiente de desenvolvimento
+
+- Siga as instruções de configuração da aplicação;
+- Instale localmente a gem `mailcatcher` executando o comando abaixo:
+```shell
+gem install mailcatcher 
+```
+- Execute o comando abaixo para iniciar o `mailcatcher`
+```shell
+mailcatcher
+```
+- Acesse o MailCatcher através do endereço `http://localhost:1080`. Todos e-mails enviados serão mostrados nessa página, que emula uma caixa de entrada.
 
 ## Como rodar os testes da aplicação
 

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -38,9 +38,12 @@ Rails.application.configure do
   config.active_storage.service = :local
 
   # Don't care if the mailer can't send.
-  config.action_mailer.raise_delivery_errors = false
 
   config.action_mailer.perform_caching = false
+  config.action_mailer.default_url_options = { host: 'localhost', port: 4000 }
+  config.action_mailer.delivery_method = :smtp
+  config.action_mailer.smtp_settings = { :address => '127.0.0.1', :port => 1025 }
+  config.action_mailer.raise_delivery_errors = false
 
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log
@@ -75,7 +78,6 @@ Rails.application.configure do
   # Raise error when a before_action's only/except options reference missing actions
   config.action_controller.raise_on_missing_callback_actions = true
 
-  config.action_mailer.default_url_options = { host: 'localhost', port: 4000 }
 
   # Use a real queuing backend for Active Job (and separate queues per environment).
   config.active_job.queue_adapter = :solid_queue


### PR DESCRIPTION
Essa PR aborda e resolve #217 

- [x] Adiciona configurações do ActionMailer para usar MailCatcher;
- [x] Complementa o arquivo `Procfile.dev` para rodar o Solid Queue automaticamente ao executar o comando `bin/dev`
- [x] Adiciona instruções de como usar o MailCatcher no README do projeto;

![image](https://github.com/TreinaDev/td11-portfoliorrr/assets/111306649/79de8e41-1825-4f31-83d6-4dcaafda927f)

Para validar que o MailCatcher está funcionando, foram realizadas as ações que executam os três mailers existentes na aplicação, e em todos os casos os e-mails foram recebidos com sucesso.

![image](https://github.com/TreinaDev/td11-portfoliorrr/assets/111306649/1005db0d-5657-4f78-b1f4-139fd7f55876)

![image](https://github.com/TreinaDev/td11-portfoliorrr/assets/111306649/2293d2e5-3857-4f85-9f39-1b3abfffa8ee)

![image](https://github.com/TreinaDev/td11-portfoliorrr/assets/111306649/6c71d655-d5b2-4f38-8ce9-2a9bdfca88d9)
