### PR TITLE
Adiciona opção de assinatura e protege rotas pagas

### DIFF
--- a/app/assets/stylesheets/navbar.scss
+++ b/app/assets/stylesheets/navbar.scss
@@ -7,5 +7,5 @@
 }
 
 .dropdown-item:active {
-  background-color: #9030df !important; 
+  background-color: #9030df !important;
 }

--- a/app/controllers/invitation_requests_controller.rb
+++ b/app/controllers/invitation_requests_controller.rb
@@ -2,18 +2,22 @@ class InvitationRequestsController < ApplicationController
   before_action :authenticate_user!, only: %i[index]
 
   def index
-    invitation_requests = current_user.invitation_requests
-    @error = false
     @invitation_request_infos = []
+    return if current_user.subscription.inactive?
 
-    begin
-      @invitation_request_infos = InvitationRequestService::InvitationRequest.send(invitation_requests)
-    rescue StandardError
-      return @error = true
-    end
+    @error = false
+    request_data
 
     return @invitation_request_infos if params[:filter].blank?
 
     @invitation_request_infos.filter! { |request| request.status == params[:filter] }
+  end
+
+  private
+
+  def request_data
+    @invitation_request_infos = InvitationRequestService::InvitationRequest.send(current_user.invitation_requests)
+  rescue StandardError
+    @error = true
   end
 end

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -1,10 +1,12 @@
 class ProjectsController < ApplicationController
   before_action :authenticate_user!
+  before_action :authenticate_subscriber, only: :create_invitation_request
 
   def index
     @invitation_request = current_user.invitation_requests.build
     @invitation_requests = current_user.invitation_requests.pluck(:project_id).to_json
     @invitation_requests_projects_ids = current_user.invitation_requests.pluck(:project_id)
+    @free_user = !current_user.subscription.active?
   end
 
   def create_invitation_request
@@ -18,6 +20,12 @@ class ProjectsController < ApplicationController
   end
 
   private
+
+  def authenticate_subscriber
+    return if current_user.subscription.active?
+
+    redirect_to root_path, alert: t('alerts.unauthorized')
+  end
 
   def invitation_request_params
     invitation_request_params = params.require(:invitation_request).permit(:message)

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -6,7 +6,7 @@ class ProjectsController < ApplicationController
     @invitation_request = current_user.invitation_requests.build
     @invitation_requests = current_user.invitation_requests.pluck(:project_id).to_json
     @invitation_requests_projects_ids = current_user.invitation_requests.pluck(:project_id)
-    @free_user = !current_user.subscription.active?
+    @free_user = current_user.subscription.inactive?
   end
 
   def create_invitation_request

--- a/app/controllers/subscriptions_controller.rb
+++ b/app/controllers/subscriptions_controller.rb
@@ -1,4 +1,6 @@
 class SubscriptionsController < ApplicationController
+  before_action :authenticate_user!
+
   def index
     @subscription = current_user.subscription
   end

--- a/app/controllers/subscriptions_controller.rb
+++ b/app/controllers/subscriptions_controller.rb
@@ -1,0 +1,11 @@
+class SubscriptionsController < ApplicationController
+  def index
+    @subscription = current_user.subscription
+  end
+
+  def update
+    @subscription = Subscription.find params[:id]
+    @subscription.active!
+    redirect_to subscriptions_path, notice: t('.success')
+  end
+end

--- a/app/javascript/components/projects_vue.js
+++ b/app/javascript/components/projects_vue.js
@@ -45,21 +45,23 @@ export default {
   },
 
   async created() {
-    try {
-      let response = await fetch('/api/v1/projects', { signal });
-      if (response.ok) {
-        let data = await response.json();
-        if (!data.message) {
-          this.projects = data;
+    if (!freeUser) {
+      try {
+        let response = await fetch('/api/v1/projects', { signal });
+        if (response.ok) {
+          let data = await response.json();
+          if (!data.message) {
+            this.projects = data;
+          }
+        } else {
+          this.errorMsg = true;
         }
-      } else {
-        this.errorMsg = true;
-      }
-    } catch (error) {
-      if (error.name == 'AbortError') {
-        console.log('Requisição abortada');
-      } else {
-        this.errorMsg = true;
+      } catch (error) {
+        if (error.name == 'AbortError') {
+          console.log('Requisição abortada');
+        } else {
+          this.errorMsg = true;
+        }
       }
     }
   }

--- a/app/javascript/components/projects_vue.js
+++ b/app/javascript/components/projects_vue.js
@@ -10,6 +10,7 @@ export default {
       showingForm: false,
       currentProjectId: null,
       invitationRequestsProjectsIds: window.invitationRequestsProjectsIds,
+      freeUser: window.freeUser,
       errorMsg: false,
     }
   },

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -1,6 +1,6 @@
 class Subscription < ApplicationRecord
   belongs_to :user
-  enum status: { inative: 0, active: 10 }
+  enum status: { inactive: 0, active: 10 }
 
   def active!
     self.start_date = Time.zone.now.to_date

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -1,0 +1,14 @@
+class Subscription < ApplicationRecord
+  belongs_to :user
+  enum status: { inative: 0, active: 10 }
+
+  def active!
+    self.start_date = Time.zone.now.to_date
+    super
+  end
+
+  def inactive!
+    self.start_date = nil
+    super
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,6 +6,7 @@ class User < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
   has_one :profile, dependent: :destroy
+  has_one :subscription, dependent: :destroy
   has_many :posts, dependent: :nullify
   has_many :likes, dependent: :destroy
   has_many :comments, dependent: :nullify
@@ -24,6 +25,7 @@ class User < ApplicationRecord
   after_create :'create_profile!'
   after_create :subscribe_likes_mailer_job
   after_create :update_search_name
+  after_create :create_subscription
 
   def description
     if admin?

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -47,7 +47,7 @@
             <%= t('.find_connect_shine') %> <br>
             <span> <%= t('.your_profile_your_space') %> </span><br>
              <span class="text-primary fw-bold py-3"><%= t('.become_part_of_comunity') %></span> <br>
-            <%= link_to t('.create_account'), new_user_registration_path, class: 'btn btn-primary col-10 py-2 my-4 fs-4' %>
+            <%= link_to t('.create_account_btn'), new_user_registration_path, class: 'btn btn-primary col-10 py-2 my-4 fs-4' %>
           </h3>
         </div>
       </div>

--- a/app/views/invitation_requests/index.html.erb
+++ b/app/views/invitation_requests/index.html.erb
@@ -2,7 +2,7 @@
 
 <% if current_user.subscription.inactive? %>
   <div class="text-center become-premium-div mt-5">
-    <h2 class="become-premium-text"><%= t('subscriptions.become') %> <%= link_to t('subscriptions.subscriber'), subscriptions_path %> <%= t('subscriptions.see_and_request') %></h2 class="become-premium-text">
+    <h2 class="become-premium-text"><%= t('subscriptions.become') %> <%= link_to t('subscriptions.subscriber'), subscriptions_path %> <%= t('subscriptions.see_and_request') %></h2>
   </div>
 <% else %>
   <div class="container">

--- a/app/views/invitation_requests/index.html.erb
+++ b/app/views/invitation_requests/index.html.erb
@@ -1,48 +1,54 @@
 <h2 class="text-center mb-5"><%= InvitationRequest.model_name.human(count: @invitation_request_infos.length) %></h2>
 
-<div class="container">
-  <div class="row justify-content-center gap-5">
-    <%= form_with url: invitation_requests_path, method: :get, class: 'col-10 me-5 px-0' do |f| %>
-      <div class="d-flex gap-2 col-3">
-        <%= f.label :filter, class: 'd-none' %>
-        <%= f.select :filter,
-                     invitation_request_filter_options,
-                     { include_blank: 'Todas', selected: params[:filter] },
-                     class: 'form-select' %>
-        <%= f.submit t(:filter_btn  ), class: 'btn btn-sm btn-primary' %>
-      </div>
-    <% end %>
+<% if current_user.subscription.inactive? %>
+  <div class="text-center become-premium-div mt-5">
+    <h2 class="become-premium-text"><%= t('subscriptions.become') %> <strong><%= t('subscriptions.subscriber') %></strong> <%= t('subscriptions.see_and_request') %></h2 class="become-premium-text">
+  </div>
+<% else %>
+  <div class="container">
+    <div class="row justify-content-center gap-5">
+      <%= form_with url: invitation_requests_path, method: :get, class: 'col-10 me-5 px-0' do |f| %>
+        <div class="d-flex gap-2 col-3">
+          <%= f.label :filter, class: 'd-none' %>
+          <%= f.select :filter,
+                      invitation_request_filter_options,
+                      { include_blank: 'Todas', selected: params[:filter] },
+                      class: 'form-select' %>
+          <%= f.submit t(:filter_btn  ), class: 'btn btn-sm btn-primary' %>
+        </div>
+      <% end %>
 
-    <% if @invitation_request_infos.any? %>
-      <% @invitation_request_infos.each do |invitation_request| %>
-        <div class="col-5 rounded border p-3" id="request_<%= invitation_request.id %>">
-          <div class="card-body">
-            <div class="d-flex flex-column gap-4">
-              <div class="d-flex flex-column gap-2">
-                <h4 class="text-break text-dark m-0"><%= invitation_request.project_title %></h4>
-                <div class="d-flex flex-column gap-2 align-items-start">
-                  <p class="m-0"><%= invitation_request.project_description %></p>
-                  <p class="m-0 fs-sm badge text-bg-secondary"><%= invitation_request.project_category %></p>
+      <% if @invitation_request_infos.any? %>
+        <% @invitation_request_infos.each do |invitation_request| %>
+          <div class="col-5 rounded border p-3" id="request_<%= invitation_request.id %>">
+            <div class="card-body">
+              <div class="d-flex flex-column gap-4">
+                <div class="d-flex flex-column gap-2">
+                  <h4 class="text-break text-dark m-0"><%= invitation_request.project_title %></h4>
+                  <div class="d-flex flex-column gap-2 align-items-start">
+                    <p class="m-0"><%= invitation_request.project_description %></p>
+                    <p class="m-0 fs-sm badge text-bg-secondary"><%= invitation_request.project_category %></p>
+                  </div>
                 </div>
-              </div>
-              <div class="d-flex justify-content-between align-items-center">
-                <p class="m-0 text-muted">
-                  <%= t(:time_ago, time: time_ago_in_words(invitation_request.created_at)) %>
-                </p>
-                <p class="m-0 text-center <%= css_color_class(invitation_request.status.to_sym) %> fw-bold fs-5">
-                  <%= InvitationRequest.human_attribute_name("status.#{invitation_request.status}") %>
-                </p>
+                <div class="d-flex justify-content-between align-items-center">
+                  <p class="m-0 text-muted">
+                    <%= t(:time_ago, time: time_ago_in_words(invitation_request.created_at)) %>
+                  </p>
+                  <p class="m-0 text-center <%= css_color_class(invitation_request.status.to_sym) %> fw-bold fs-5">
+                    <%= InvitationRequest.human_attribute_name("status.#{invitation_request.status}") %>
+                  </p>
+                </div>
               </div>
             </div>
           </div>
-        </div>
+        <% end %>
+      <% elsif @error %>
+        <h3 class="mt-5 alert alert-warning text-center" ><%= t(:project_api_error) %></h3>
+      <% elsif params[:filter].nil? || params[:filter].blank? %>
+        <h3 class="mt-5 alert alert-warning text-center" ><%= t(:no_invitation_request_msg) %></h3>
+      <% else %>
+        <h3 class="mt-5 alert alert-warning text-center" ><%= t(:no_filter_results_msg) %></h3>
       <% end %>
-    <% elsif @error %>
-      <h3 class="mt-5 alert alert-warning text-center" ><%= t(:project_api_error) %></h3>
-    <% elsif params[:filter].nil? || params[:filter].blank? %>
-      <h3 class="mt-5 alert alert-warning text-center" ><%= t(:no_invitation_request_msg) %></h3>
-    <% else %>
-      <h3 class="mt-5 alert alert-warning text-center" ><%= t(:no_filter_results_msg) %></h3>
-    <% end %>
+    </div>
   </div>
-</div>
+<% end %>

--- a/app/views/invitation_requests/index.html.erb
+++ b/app/views/invitation_requests/index.html.erb
@@ -2,7 +2,7 @@
 
 <% if current_user.subscription.inactive? %>
   <div class="text-center become-premium-div mt-5">
-    <h2 class="become-premium-text"><%= t('subscriptions.become') %> <strong><%= t('subscriptions.subscriber') %></strong> <%= t('subscriptions.see_and_request') %></h2 class="become-premium-text">
+    <h2 class="become-premium-text"><%= t('subscriptions.become') %> <%= link_to t('subscriptions.subscriber'), subscriptions_path %> <%= t('subscriptions.see_and_request') %></h2 class="become-premium-text">
   </div>
 <% else %>
   <div class="container">

--- a/app/views/projects/index.html.erb
+++ b/app/views/projects/index.html.erb
@@ -2,7 +2,7 @@
   <h2 class="text-center"><%= t('.index_title') %> </h2>
 
   <div v-if="freeUser" class="text-center become-premium-div mt-5">
-    <h2 class="become-premium-text"><%= t('subscriptions.become') %> <strong><%= t('subscriptions.subscriber') %></strong> <%= t('subscriptions.see_listed_projects') %></h2 class="become-premium-text">
+    <h2 class="become-premium-text"><%= t('subscriptions.become') %> <%= link_to t('subscriptions.subscriber'), subscriptions_path %> <%= t('subscriptions.see_listed_projects') %></h2 class="become-premium-text">
   </div>
 
   <div v-else-if="emptyData" class="text-center">

--- a/app/views/projects/index.html.erb
+++ b/app/views/projects/index.html.erb
@@ -1,7 +1,11 @@
 <div class="container" id="vue-projects-app">
   <h2 class="text-center"><%= t('.index_title') %> </h2>
 
-  <div v-if="emptyData" class="text-center">
+  <div v-if="freeUser" class="text-center">
+    <p>Torne-se assinante para ver projetos listados</p>
+  </div>
+
+  <div v-else-if="emptyData" class="text-center">
     <p>{{ emptyData }}</p>
   </div>
 
@@ -71,4 +75,5 @@
 
 <script>
   var invitationRequestsProjectsIds = <%= @invitation_requests_projects_ids %>
+  var freeUser = <%= @free_user %>
 </script>

--- a/app/views/projects/index.html.erb
+++ b/app/views/projects/index.html.erb
@@ -1,8 +1,8 @@
 <div class="container" id="vue-projects-app">
   <h2 class="text-center"><%= t('.index_title') %> </h2>
 
-  <div v-if="freeUser" class="text-center">
-    <p>Torne-se assinante para ver projetos listados</p>
+  <div v-if="freeUser" class="text-center become-premium-div mt-5">
+    <h2 class="become-premium-text"><%= t('subscriptions.become') %> <strong><%= t('subscriptions.subscriber') %></strong> <%= t('subscriptions.see_listed_projects') %></h2 class="become-premium-text">
   </div>
 
   <div v-else-if="emptyData" class="text-center">
@@ -44,7 +44,7 @@
     <h3 v-else-if="projects.length == 0 && !errorMsg" class="mt-5 alert alert-warning text-center">
       <%= t('.errors.no_result') %>
     </h3>
-    
+
     <div v-else>
       <div class="mt-5 border-top w-50 mx-auto" v-for="project in filteredProjects" :key="project.id">
         <h3 class="mt-3">{{ project.title }}</h3>

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -63,7 +63,7 @@
             </li>
             <div class="dropdown-divider"></div>
             <li class="dropdown-item" href="#">
-              <%= link_to Subscription.model_name.human, subscriptions_path(current_user.subscription), class: 'nav-link text-primary' %>
+              <%= link_to Subscription.model_name.human, subscriptions_path, class: 'nav-link text-primary' %>
             </li>
             <li class="dropdown-item">
               <%= link_to t('projects.model.other'), projects_path, class: 'nav-link text-primary' %>

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -34,12 +34,6 @@
               <%= link_to "#{current_user.description}", current_user.profile, class: 'nav-link' %>
             </li>
             <li class="dropdown-item">
-              <%= link_to t('projects.model.other'), projects_path, class: 'nav-link' %>
-            </li>
-            <li class="dropdown-item">
-              <%= link_to InvitationRequest.model_name.human(count: 2), invitation_requests_path, class: 'nav-link' %>
-            </li>
-            <li class="dropdown-item">
               <%= link_to Invitation.model_name.human(count: 2), invitations_path, class: 'nav-link' %>
             </li>
             <li class="dropdown-item">
@@ -66,6 +60,16 @@
             </li>
             <li class="dropdown-item" href="#">
               <%= link_to t('settings.index.settings'), profile_settings_path(current_user.profile), class: 'nav-link' %>
+            </li>
+            <div class="dropdown-divider"></div>
+            <li class="dropdown-item" href="#">
+              <%= link_to Subscription.model_name.human, subscriptions_path(current_user.subscription), class: 'nav-link text-primary' %>
+            </li>
+            <li class="dropdown-item">
+              <%= link_to t('projects.model.other'), projects_path, class: 'nav-link text-primary' %>
+            </li>
+            <li class="dropdown-item">
+              <%= link_to InvitationRequest.model_name.human(count: 2), invitation_requests_path, class: 'nav-link text-primary' %>
             </li>
             <li class="dropdown-item" href="#">
               <%= button_to t('log_out'), destroy_user_session_path, method: :delete, class: 'btn btn-danger w-100' %>

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -37,10 +37,10 @@
               <%= link_to t('projects.model.other'), projects_path, class: 'nav-link' %>
             </li>
             <li class="dropdown-item">
-              <%= link_to Invitation.model_name.human(count: 2), invitations_path, class: 'nav-link' %>
+              <%= link_to InvitationRequest.model_name.human(count: 2), invitation_requests_path, class: 'nav-link' %>
             </li>
             <li class="dropdown-item">
-              <%= link_to 'Solicitações de Convites', invitation_requests_path, class: 'nav-link' %>
+              <%= link_to Invitation.model_name.human(count: 2), invitations_path, class: 'nav-link' %>
             </li>
             <li class="dropdown-item">
               <%= link_to notifications_path, class: 'nav-link' do %>

--- a/app/views/subscriptions/index.html.erb
+++ b/app/views/subscriptions/index.html.erb
@@ -1,0 +1,46 @@
+<h2 class="text-center"><%= Subscription.model_name.human %></h2>
+
+<div class="container justify-items-center text-center mt-5">
+  <div class="d-flex row gap-5 justify-content-center">
+    <div class="card column col-4 shadow">
+      <div id="free-account-div" class="card-body d-flex flex-column justify-content-between">
+        <div>
+          <h3 class="card-title"><%= t('.free_account') %></h3>
+
+          <ul class="list-group">
+            <li class="list-group-item"><%= t('.platform_access') %></li>
+            <li class="list-group-item"><%= t('.searchable_content') %></li>
+            <li class="list-group-item"><%= t('.hiring_capabilities') %></li>
+          </ul>
+        </div>
+
+        <% if current_user.subscription.inactive? %>
+          <div class="card-footer">
+            <h4><%= t('.current_tier') %></h4>
+          </div>
+        <% end %>
+      </div>
+    </div>
+
+    <div class="card column col-4 shadow">
+      <div id="premium-account-div" class="card-body d-flex flex-column justify-content-between">
+        <h3 class="card-title"><%= t('.premium_account') %></h3>
+
+        <ul class="list-group">
+          <li class="list-group-item"><%= t('.projects_access') %></li>
+          <li class="list-group-item"><%= t('.highlight_in_search_results')%></li>
+          <li class="list-group-item"><%= t('.request_invitation') %></li>
+          <li class="list-group-item"><%= t('.no_ads') %></li>
+        </ul>
+
+        <% if current_user.subscription.inactive? %>
+          <%= button_to t('.subscribe_btn'), subscription_path(current_user.subscription), method: :patch, class: "btn btn-primary btn-lg mt-4" %>
+        <% else %>
+          <div class="card-footer">
+            <h4><%= t('.current_tier') %></h4>
+          </div>
+        <% end %>
+      </div>
+    </div>
+  </div>
+</div>

--- a/config/locales/home.pt-BR.yml
+++ b/config/locales/home.pt-BR.yml
@@ -9,10 +9,10 @@ pt-BR:
       find_connect_shine: Descubra, Conecte, Brilhe
       your_profile_your_space: Seu Portfólio, Seu Espaço
       become_part_of_comunity: Faça parte da nossa comunidade!
-      create_account: Crie já a sua conta
-      find_out_more: 
+      create_account_btn: Crie já a sua conta
+      find_out_more:
         do: Faça
-        or: ou 
+        or: ou
         find_out: para descobrir conteúdos relevantes para você.
       login: login
       create_account: crie uma conta

--- a/config/locales/subscription.pt-BR.yml
+++ b/config/locales/subscription.pt-BR.yml
@@ -8,3 +8,18 @@ pt-BR:
     subscriber: assinante
     see_listed_projects: para ver projetos listados
     see_and_request: para ver e fazer solicitações
+    update:
+      success: Assinatura atualizada com sucesso!
+    index:
+      already_subscribed: Você já é assinante
+      subscribe_btn: Assinar
+      current_tier: Plano atual
+      free_account: Conta Gratuita
+      premium_account: Conta Premium
+      platform_access: Acesso à Perfis, Publicações
+      searchable_content: Pesquisa por outros usuários ou publicações
+      hiring_capabilities: Possibilidade de ser convidado para um projeto
+      projects_access: Acesso à pesquisas de projetos na plataforma parceira Cola?bora!
+      highlight_in_search_results: Destaque nos resultados das pesquisas por líderes de projetos.
+      no_ads: Zero anúncios na plataforma.
+      request_invitation: Solicitações de convites para participação de projetos ilimitadas.

--- a/config/locales/subscription.pt-BR.yml
+++ b/config/locales/subscription.pt-BR.yml
@@ -1,0 +1,10 @@
+pt-BR:
+  activerecord:
+    models:
+      subscription: Assinatura
+
+  subscriptions:
+    become: Torne-se
+    subscriber: assinante
+    see_listed_projects: para ver projetos listados
+    see_and_request: para ver e fazer solicitações

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,6 +21,8 @@ Rails.application.routes.draw do
     post 'pin', on: :member
   end
 
+  resources :subscriptions, only: %i[index show update]
+
   resources :reports, only: %i[index new create show] do
     post 'reject', 'remove_content', on: :member
   end
@@ -63,7 +65,7 @@ Rails.application.routes.draw do
       resources :profiles, only: %i[show index]
       resources :invitations, only: %i[create update]
       resources :invitation_request, only: %i[update]
-      
+
       get 'projects/request_invitation', controller: :projects
     end
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,7 +21,7 @@ Rails.application.routes.draw do
     post 'pin', on: :member
   end
 
-  resources :subscriptions, only: %i[index show update]
+  resources :subscriptions, only: %i[index update]
 
   resources :reports, only: %i[index new create show] do
     post 'reject', 'remove_content', on: :member

--- a/db/migrate/20240214151256_create_subscriptions.rb
+++ b/db/migrate/20240214151256_create_subscriptions.rb
@@ -1,0 +1,11 @@
+class CreateSubscriptions < ActiveRecord::Migration[7.1]
+  def change
+    create_table :subscriptions do |t|
+      t.references :user, null: false, foreign_key: true
+      t.date :start_date
+      t.integer :status, default: 0
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_02_12_195603) do
+ActiveRecord::Schema[7.1].define(version: 2024_02_14_151256) do
   create_table "action_text_rich_texts", force: :cascade do |t|
     t.string "name", null: false
     t.text "body"
@@ -311,6 +311,15 @@ ActiveRecord::Schema[7.1].define(version: 2024_02_12_195603) do
     t.index ["key"], name: "index_solid_queue_semaphores_on_key", unique: true
   end
 
+  create_table "subscriptions", force: :cascade do |t|
+    t.integer "user_id", null: false
+    t.date "start_date"
+    t.integer "status", default: 0
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_subscriptions_on_user_id"
+  end
+
   create_table "taggings", force: :cascade do |t|
     t.integer "tag_id"
     t.string "taggable_type"
@@ -385,5 +394,6 @@ ActiveRecord::Schema[7.1].define(version: 2024_02_12_195603) do
   add_foreign_key "solid_queue_failed_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
   add_foreign_key "solid_queue_ready_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
   add_foreign_key "solid_queue_scheduled_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
+  add_foreign_key "subscriptions", "users"
   add_foreign_key "taggings", "tags"
 end

--- a/spec/factories/subscriptions.rb
+++ b/spec/factories/subscriptions.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :subscription do
-    user { nil }
-    start_date { "2024-02-14" }
-    status { 1 }
+    user
+    start_date { nil }
+    status { 0 }
   end
 end

--- a/spec/factories/subscriptions.rb
+++ b/spec/factories/subscriptions.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :subscription do
+    user { nil }
+    start_date { "2024-02-14" }
+    status { 1 }
+  end
+end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -17,7 +17,7 @@ FactoryBot.define do
 
     trait :free do
       after(:create) do |user|
-        user.subscription.inative!
+        user.subscription.inactive!
       end
     end
   end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -5,9 +5,19 @@ FactoryBot.define do
     email { Faker::Internet.email }
     password { '123456' }
 
+    after(:create) do |user|
+      user.subscription.active!
+    end
+
     trait :seed do
       after(:build) do |user|
         user.class.skip_callback(:create, :after, :create_profile!, raise: false)
+      end
+    end
+
+    trait :free do
+      after(:create) do |user|
+        user.subscription.inative!
       end
     end
   end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -20,5 +20,11 @@ FactoryBot.define do
         user.subscription.inactive!
       end
     end
+
+    trait :paid do
+      after(:create) do |user|
+        user.subscription.active!
+      end
+    end
   end
 end

--- a/spec/models/subscription_spec.rb
+++ b/spec/models/subscription_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Subscription, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/subscription_spec.rb
+++ b/spec/models/subscription_spec.rb
@@ -1,5 +1,25 @@
 require 'rails_helper'
 
 RSpec.describe Subscription, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  describe '#active!' do
+    it 'atualiza data de início automaticamente' do
+      subscription = create(:subscription, status: :inactive, start_date: nil)
+
+      subscription.active!
+
+      expect(subscription.start_date).to eq Time.zone.now.to_date
+      expect(subscription).to be_active
+    end
+  end
+
+  describe '#active!' do
+    it 'atualiza data de início automaticamente' do
+      subscription = create(:subscription, status: :active, start_date: Time.zone.now)
+
+      subscription.inactive!
+
+      expect(subscription.start_date).to be_nil
+      expect(subscription).to be_inactive
+    end
+  end
 end

--- a/spec/requests/invitation_requests/user_creates_invitation_request_spec.rb
+++ b/spec/requests/invitation_requests/user_creates_invitation_request_spec.rb
@@ -39,4 +39,19 @@ describe 'Usuário solicita convite para um projeto' do
     expect(response).to redirect_to(new_user_session_path)
     expect(flash[:alert]).to eq('Para continuar, faça login ou registre-se.')
   end
+
+  it 'e deve possuir conta premium' do
+    user = create(:user, :free)
+    login_as user
+
+    post invitation_request_path, params: {
+      'project_id' => 1,
+      'invitation_request' => {
+        'message' => 'Me convida'
+      }
+    }
+
+    expect(response).to redirect_to(root_path)
+    expect(flash[:alert]).to eq('Você não têm permissão para realizar essa ação.')
+  end
 end

--- a/spec/system/subscription/free_user_spec.rb
+++ b/spec/system/subscription/free_user_spec.rb
@@ -24,4 +24,42 @@ describe 'Usuário não assinante' do
     expect(page).to have_current_path(projects_path)
     expect(page).to have_content 'Torne-se assinante para ver projetos listados'
   end
+
+  it 'se vê página para se tornar assinante' do
+    user = create(:user, :free)
+
+    login_as user
+    visit root_path
+    click_button class: 'dropdown-toggle'
+    click_on 'Assinatura'
+
+    within '#free-account-div' do
+      expect(page).to have_content 'Plano atual'
+    end
+
+    within '#premium-account-div' do
+      expect(page).to have_button 'Assinar'
+      expect(page).to have_content 'Acesso à pesquisas de projetos na plataforma parceira Cola?bora!'
+      expect(page).to have_content 'Destaque nos resultados das pesquisas por líderes de projetos.'
+      expect(page).to have_content 'Solicitações de convites para participação de projetos ilimitadas.'
+      expect(page).to have_content 'Zero anúncios na plataforma.'
+    end
+  end
+
+  it 'se torna assinante' do
+    user = create(:user, :free)
+
+    login_as user
+    visit root_path
+    click_button class: 'dropdown-toggle'
+    click_on 'Assinatura'
+    click_on 'Assinar'
+
+    expect(page).not_to have_content 'Assinar'
+    expect(user.subscription.reload).to be_active
+    expect(page).to have_content 'Assinatura atualizada com sucesso!'
+    within '#premium-account-div' do
+      expect(page).to have_content 'Plano atual'
+    end
+  end
 end

--- a/spec/system/subscription/free_user_spec.rb
+++ b/spec/system/subscription/free_user_spec.rb
@@ -9,7 +9,7 @@ describe 'Usuário não assinante' do
     click_button class: 'dropdown-toggle'
     click_on 'Solicitações de Convite'
 
-    expect(page).to have_current_path(projects_path)
+    expect(page).to have_current_path(invitation_requests_path)
     expect(page).to have_content 'Torne-se assinante para ver e fazer solicitações'
   end
 

--- a/spec/system/subscription/free_user_spec.rb
+++ b/spec/system/subscription/free_user_spec.rb
@@ -1,0 +1,27 @@
+require 'rails_helper'
+
+describe 'Usuário não assinante' do
+  it 'acessa página de solicitações e recebe mensagem para se tornar assinante' do
+    user = create(:user, :free)
+
+    login_as user
+    visit root_path
+    click_button class: 'dropdown-toggle'
+    click_on 'Solicitações de Convite'
+
+    expect(page).to have_current_path(projects_path)
+    expect(page).to have_content 'Torne-se assinante para ver e fazer solicitações'
+  end
+
+  it 'acessa página de projetos e recebe mensagem para se tornar assinante' do
+    user = create(:user, :free)
+
+    login_as user
+    visit root_path
+    click_button class: 'dropdown-toggle'
+    click_on 'Projetos'
+
+    expect(page).to have_current_path(projects_path)
+    expect(page).to have_content 'Torne-se assinante para ver projetos listados'
+  end
+end

--- a/spec/system/subscription/paid_user_spec.rb
+++ b/spec/system/subscription/paid_user_spec.rb
@@ -1,0 +1,30 @@
+require 'rails_helper'
+
+describe 'Usuário assinante' do
+  it 'acessa página de solicitações' do
+    user = create(:user, :paid)
+
+    login_as user
+    visit root_path
+    click_button class: 'dropdown-toggle'
+    click_on 'Solicitações de Convite'
+
+    expect(page).to have_current_path(invitation_requests_path)
+    expect(page).to have_button 'Filtrar'
+    expect(page).not_to have_content 'Torne-se assinante para ver e fazer solicitações'
+  end
+
+  it 'acessa página de projetos' do
+    user = create(:user, :paid)
+
+    login_as user
+    visit root_path
+    click_button class: 'dropdown-toggle'
+    click_on 'Projetos'
+
+    expect(page).to have_current_path(projects_path)
+    expect(page).not_to have_content 'Torne-se assinante para ver projetos listados'
+    expect(page).to have_button 'Título'
+    expect(page).to have_button 'Todos'
+  end
+end

--- a/spec/system/subscription/visitor_user_spec.rb
+++ b/spec/system/subscription/visitor_user_spec.rb
@@ -1,0 +1,10 @@
+require 'rails_helper'
+
+describe 'Visitante' do
+  it 'Visitante acessa página de inscrições e é redirecionado' do
+    visit subscriptions_path
+
+    expect(page).to have_current_path new_user_session_path
+    expect(page).to have_content 'Para continuar, faça login ou registre-se.'
+  end
+end


### PR DESCRIPTION
## Alcançado com este PR

Resolve #210 
Resolve #211 

Adicionamos o modelo de assinaturas atrelada ao usuário, tendo o status de ativa ou não ativa. 

No caso de ativa, o usuário tem acesso às páginas de pesquisa de projetos e solicitação de convites.
No caso de inativa, ao entrar nessas páginas, o usuário vê uma mensagem dizendo que é só para assinantes, com um link para a tela de assinatura.

Quando uma assinatura é ativada, tem sua start_date atribuída automaticamente para o dia atual. E start_date nulificada quando a assinatura é desativada.

A tela de assinatura foi implementada e no momento um usuário pode apenas se tornar assinante, não consegue cancelar a inscrição. 

### Prints

- Tela bloqueada com a mensagem
![image](https://github.com/TreinaDev/td11-portfoliorrr/assets/105655467/80c39c01-fb49-4f3f-9ce2-6f9aec2bd537)
![image](https://github.com/TreinaDev/td11-portfoliorrr/assets/105655467/d294d755-108c-49bd-9313-f4bc4efd19e1)

- Tela de assinatura
![image](https://github.com/TreinaDev/td11-portfoliorrr/assets/105655467/851780fc-fe1a-4c85-8a6a-28d4cc7436d4)

- Navbar com destaque
![image](https://github.com/TreinaDev/td11-portfoliorrr/assets/105655467/be493cc6-e75a-4968-b54b-6bb466d46026)

