### PR TITLE
Feat/Usuário pode publicar publicação programada

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,6 +1,6 @@
 class PostsController < ApplicationController
   before_action :authenticate_user!, only: %w[new create edit pin]
-  before_action :set_post, only: %w[show edit update pin]
+  before_action :set_post, only: %w[show edit update pin publish]
   before_action :authorize!, only: %w[edit update pin]
   before_action :blocks_update, only: %w[update]
   before_action :redirect_if_removed_content, only: %w[show edit update pin]
@@ -50,6 +50,11 @@ class PostsController < ApplicationController
       @post.unpinned!
       redirect_to profile_path(current_user), notice: t('.unpinned.success')
     end
+  end
+
+  def publish
+    @post.published!
+    redirect_to post_path(@post), notice: t('.success')
   end
 
   private

--- a/app/jobs/post_scheduler_job.rb
+++ b/app/jobs/post_scheduler_job.rb
@@ -2,7 +2,8 @@ class PostSchedulerJob < ApplicationJob
   queue_as :default
 
   def perform(post)
+    return if post.published?
+
     post.published!
-    post.update(published_at: Time.zone.now)
   end
 end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -40,6 +40,11 @@ class Post < ApplicationRecord
     end
   end
 
+  def published!
+    super
+    update(published_at: Time.current)
+  end
+
   private
 
   def create_notification_to_followers

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -1,9 +1,11 @@
 <div class="card text-muted">
   <div class="card-body">
     <h2 class="card-title"><%= @post.title %></h2>
-    <div class="my-4">
+    <div class="my-4 d-flex gap-1">
       <% if current_user == @post.user %>
         <%= link_to t('edit_btn'), edit_post_path(@post), class: 'btn btn-primary', data: { turbo: false } %>
+        <%= button_to t('publish_btn'), publish_post_path(@post), method: :patch,
+          class: 'btn btn-primary', data: { turbo: false } if @post.scheduled? %>
         <%= Post.human_attribute_name @post.status %>
       <% else %>
         <%= link_to t('reports.report_btn'), new_report_path(reportable: @post, reportable_type: @post.class), class: 'btn btn-secondary btn-sm' %>

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -12,7 +12,9 @@
 
     <div id="publications">
       <h2 id="post-list-title"><%= Post.model_name.human(count: 2) %></h2>
-      <% if @profile.user.posts.count - @profile.user.posts.pinned.count < 1 %>
+      <% published_posts = @profile.user.posts.published %>
+      
+      <% if published_posts.count - @profile.user.posts.pinned.count < 1 %>
         <p><%= t('.nothing_here') %> <br> <%= t('.new_posts') %> :)</p>
       <% end %>
 

--- a/config/locales/buttons.pt-BR.yml
+++ b/config/locales/buttons.pt-BR.yml
@@ -10,3 +10,4 @@ pt-BR:
   unpin_btn: Desafixar
   return_btn: Voltar
   send_btn: Enviar
+  publish_btn: Publicar

--- a/config/locales/models/posts.pt-BR.yml
+++ b/config/locales/models/posts.pt-BR.yml
@@ -21,6 +21,8 @@ pt-BR:
         status_draft: Rascunho
         status_published: Publicada
   posts:
+    publish:
+      success: Publicada com sucesso!
     redirect_alert:
       invalid_user: Você não pode acessar este conteúdo ou realizar esta ação
     create:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -30,6 +30,7 @@ Rails.application.routes.draw do
   end
 
   resources :posts, only: %i[] do
+    patch 'publish', on: :member
     resources :likes, only: %i[create destroy], module: :posts
 
     end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -55,8 +55,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_02_14_134106) do
     t.integer "user_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.text "old_message"
     t.integer "status", default: 0
+    t.text "old_message"
     t.index ["post_id"], name: "index_comments_on_post_id"
     t.index ["user_id"], name: "index_comments_on_user_id"
   end
@@ -162,7 +162,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_02_14_134106) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "pin", default: 0
-    t.datetime "edited_at", default: "2024-02-13 03:11:57"
+    t.datetime "edited_at"
     t.integer "status", default: 0
     t.datetime "published_at"
     t.string "old_status"

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -54,6 +54,7 @@ RSpec.describe Post, type: :model do
       expect(Post.get_sample(5).count).to eq 3
     end
   end
+
   describe '#pinned' do
     it 'e não altera o edited_at' do
       user = create(:user)
@@ -69,5 +70,16 @@ RSpec.describe Post, type: :model do
     post = Post.new
 
     expect(post.status).to eq 'published'
+  end
+
+  describe '#published!' do
+    it 'deve alterar status para published e atualizar published_at' do
+      post = create(:post, status: 'scheduled', published_at: 1.day.from_now)
+
+      post.published!
+
+      expect(post.reload).to be_published
+      expect(post.reload.published_at.to_date).to eq Time.current.to_date
+    end
   end
 end

--- a/spec/system/posts/user_publish_scheduled_post_spec.rb
+++ b/spec/system/posts/user_publish_scheduled_post_spec.rb
@@ -1,0 +1,16 @@
+require 'rails_helper'
+
+describe 'Usuário publica um post agendado' do
+  it 'comm sucesso' do
+    post = create(:post, status: :scheduled, published_at: 1.day.from_now)
+
+    login_as post.user
+    visit post_path(post)
+    click_on 'Publicar'
+
+    expect(page).to have_content 'Publicada com sucesso'
+    expect(page).to have_content 'Publicada'
+    expect(post.reload).to be_published
+    expect(page).not_to have_button 'Publicar'
+  end
+end


### PR DESCRIPTION
Essa PR abrange e resolve #227 e resolve #228.

Usuário pode publicar um post agendado antes da hora:
![image](https://github.com/TreinaDev/td11-portfoliorrr/assets/101219858/8bb26618-ac84-468a-ac72-4fa09115b06e)

Ao realizar ação status do post é alterado pra publicado, published_at atualizado com data atual e opção publicar é removida:
![image](https://github.com/TreinaDev/td11-portfoliorrr/assets/101219858/b12513cb-8605-4494-94ee-6400fa622319)

Metodo published! sobreescrito para atualizar published_at além do status.

Também corrige mensagem para quando usuário visita outro perfil e não há publicações. Agora mesmo com publiações agendadas a mensagem será exibida.
![image](https://github.com/TreinaDev/td11-portfoliorrr/assets/101219858/08e27d15-3340-4e3d-9e78-599c1c935817)
