### PR TITLE
[Fix] Páginas com publicações quebradas (published_at e edited_at nulos)

### DIFF
--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -32,9 +32,11 @@
       </p>
     <% end %>
     <p>
-      <time datetime="<%= @post.edited_at.to_date %>">
-        <%= t('.last_update', update_date: I18n.l(@post.edited_at.to_datetime, format: :long)) %>
-      </time>
+      <% if @post.edited_at.present? %>
+        <time datetime="<%= @post.edited_at.to_date %>">
+          <%= t('.last_update', update_date: I18n.l(@post.edited_at.to_datetime, format: :long)) %>
+        </time>
+      <% end %>
     </p>
 
     <p class="card-subtitle mb-2 text-body-secondary tags">

--- a/app/views/reports/_post.html.erb
+++ b/app/views/reports/_post.html.erb
@@ -7,16 +7,26 @@
 
     <p class="card-text"><%= post.content %></p>
 
-    <p class="card-subtitle mb-2">
-      <time datetime="<%= post.published_at.to_datetime %>">
-        <%= Post.human_attribute_name :published_at %> <%= I18n.l(post.published_at.to_datetime, format: :long) %>
-      </time>
-    </p>
-    <p>
-      <time datetime="<%= post.edited_at.to_date %>">
-        <%= t('posts.show.last_update', update_date: I18n.l(post.edited_at.to_datetime, format: :long)) %>
-      </time>
-    </p>
+    <% if post.published_at.present? %>
+      <p class="card-subtitle mb-2">
+        <time datetime="<%= post.published_at.to_datetime %>">
+          <%= Post.human_attribute_name :published_at %> <%= I18n.l(post.published_at.to_datetime, format: :long) %>
+        </time>
+      </p>
+    <% else %>
+      <p class="card-subtitle mb-2">
+        <time datetime="<%= post.created_at.to_datetime %>">
+          <%= Post.human_attribute_name :published_at %> <%= I18n.l(post.created_at.to_datetime, format: :long) %>
+        </time>
+      </p>
+    <% end %>
+    <% if post.edited_at.present? %>
+      <p>
+        <time datetime="<%= post.edited_at.to_date %>">
+          <%= t('posts.show.last_update', update_date: I18n.l(post.edited_at.to_datetime, format: :long)) %>
+        </time>
+      </p>
+    <% end %>
 
     <p class="card-subtitle mb-2 text-body-secondary tags">
       <% post.tags.each do |tag| %>


### PR DESCRIPTION
Essa PR aborda e resolve #242 

### Objetivos alcançados

Foi detectado que algumas páginas que mostram informações sobre data de publicação e data de edição do perfil estavam quebrando, por esperar que esses parâmetros não-obrigatórios fossem passados para a view. Essa PR adiciona os condicionais necessários para driblar essas necessidades e:

- Apresentar `created_at` caso `published_at` não exista;
- Não mostrar data de edição caso ela não exista;