### PR TITLE
[Fix] Bug de pin/unpin

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -46,10 +46,10 @@ class PostsController < ApplicationController
   def pin
     if @post.unpinned?
       @post.pinned!
-      redirect_to profile_path(current_user), notice: t('.pinned.success')
+      redirect_to profile_path(current_user.profile.slug), notice: t('.pinned.success')
     else
       @post.unpinned!
-      redirect_to profile_path(current_user), notice: t('.unpinned.success')
+      redirect_to profile_path(current_user.profile.slug), notice: t('.unpinned.success')
     end
   end
 

--- a/app/controllers/professional_infos_controller.rb
+++ b/app/controllers/professional_infos_controller.rb
@@ -8,7 +8,7 @@ class ProfessionalInfosController < ApplicationController
   end
 
   def create
-    @professional_info = current_user.profile.professional_infos.build(professional_info_params)
+    @professional_info = current_user.professional_infos.build(professional_info_params)
 
     if @professional_info.save
       redirect_to profile_path(current_user.profile.slug), notice: t('.success')

--- a/app/controllers/professional_infos_controller.rb
+++ b/app/controllers/professional_infos_controller.rb
@@ -11,7 +11,7 @@ class ProfessionalInfosController < ApplicationController
     @professional_info = current_user.profile.professional_infos.build(professional_info_params)
 
     if @professional_info.save
-      redirect_to profile_path(current_user.profile), notice: t('.success')
+      redirect_to profile_path(current_user.profile.slug), notice: t('.success')
     else
       flash.now[:alert] = t('.error')
       render :new, status: :unprocessable_entity
@@ -22,7 +22,7 @@ class ProfessionalInfosController < ApplicationController
 
   def update
     if @professional_info.update(professional_info_params)
-      redirect_to profile_path(current_user.profile), notice: t('.success')
+      redirect_to profile_path(current_user.profile.slug), notice: t('.success')
     else
       flash.now[:alert] = t('.error')
       render :edit, status: :unprocessable_entity

--- a/app/views/connections_mailer/notify_follow.html.erb
+++ b/app/views/connections_mailer/notify_follow.html.erb
@@ -1,6 +1,6 @@
 <p><%= t('.greeting', recipient: @notification.profile.full_name) %></p>
 
-<p><%= link_to @notification.notifiable.follower.full_name, profile_url(@notification.notifiable.follower) %> <%= t('notifications.started_following_you') %></p>
+<p><%= link_to @notification.notifiable.follower.full_name, profile_url(@notification.notifiable.follower.slug) %> <%= t('notifications.started_following_you') %></p>
 
 <p><%= link_to t('click_btn'), @notification.profile %> <%= t('.access_profile') %></p>
 <%= t('.regards') %>

--- a/app/views/education_infos/_form.html.erb
+++ b/app/views/education_infos/_form.html.erb
@@ -20,5 +20,5 @@
 </p>
 <p class='mt-3'>
   <%= education_info.submit t('save_btn'), class:'btn btn-primary' %>
-  <%= link_to t('return_btn'), profile_path(current_user.profile), class: 'btn btn-secondary' %>
+  <%= link_to t('return_btn'), profile_path(current_user.profile.slug), class: 'btn btn-secondary' %>
 </p>

--- a/app/views/likes_mailer/notify_like.html.erb
+++ b/app/views/likes_mailer/notify_like.html.erb
@@ -12,6 +12,6 @@
   <p><%= t('.most_liked_comment', comment: @most_liked_comment.message) %> <%= link_to @most_liked_comment.post.title, post_url(@most_liked_comment.post) %></p>
 <% end %>
 
-<p><%= link_to t('click_btn'), profile_url(@user.profile) %> <%= t('.access_profile') %></p>
+<p><%= link_to t('click_btn'), profile_url(@user.profile.slug) %> <%= t('.access_profile') %></p>
 <%= t('.regards') %>,
 <p>Portfoliorrr</p>

--- a/app/views/professional_infos/_form.html.erb
+++ b/app/views/professional_infos/_form.html.erb
@@ -28,5 +28,5 @@
   </p>
   <p class='mt-3'>
     <%= professional_info.submit t('save_btn'), class:'btn btn-primary' %>
-    <%= link_to t('return_btn'), profile_path(current_user.profile), class: 'btn btn-secondary' %>
+    <%= link_to t('return_btn'), profile_path(current_user.profile.slug), class: 'btn btn-secondary' %>
   </p>

--- a/app/views/profile_job_categories/new.html.erb
+++ b/app/views/profile_job_categories/new.html.erb
@@ -17,6 +17,6 @@
   </div>
   <div class="mb-3">
     <%= f.submit t('save_btn'), class: 'btn btn-primary' %>
-    <%= link_to t('return_btn'), profile_path(current_user.profile), class: 'btn btn-secondary' %>
+    <%= link_to t('return_btn'), profile_path(current_user.profile.slug), class: 'btn btn-secondary' %>
   </div>
 <% end %>

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -5,7 +5,7 @@
       <div id="fixed">
         <div class="mb-3 border-bottom border-dark">
           <h2 id="post-list-title"><%= t('.highlight') %></h2>
-        </div
+        </div>
         <section>
           <%= render partial: 'posts/listing', locals: { posts: @posts.pinned } %>
         </section>

--- a/spec/mailer/connections_mailer_spec.rb
+++ b/spec/mailer/connections_mailer_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe ConnectionsMailer, type: :mailer do
       expect(mail.subject).to include 'Alguém seguiu seu perfil'
       expect(mail.to).to eq [followed_profile.email]
       expect(mail.from).to eq ['notifications@portfoliorrr.com']
-      expect(mail.body).to include "<a href=\"#{profile_url(follower.profile)}\">"
+      expect(mail.body).to include "<a href=\"#{profile_url(follower.profile.slug)}\">"
       expect(mail.body).to include 'Danilo Martins</a> começou a seguir você'
     end
   end

--- a/spec/mailers/likes_mailer_spec.rb
+++ b/spec/mailers/likes_mailer_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe LikesMailer, type: :mailer do
       expect(mail.body).to include "A publicação mais curtida foi <a href=\"#{post_url(post_b)}\">#{post_b.title}</a>"
       expect(mail.body).to include "O seu comentário mais curtido foi #{comment.message} na publicação "
       expect(mail.body).to include "<a href=\"#{post_url(comment.post)}\">#{comment.post.title}</a>"
-      expect(mail.body).to have_link 'Clique aqui', href: profile_url(user.profile)
+      expect(mail.body).to have_link 'Clique aqui', href: profile_url(user.profile.slug)
       expect(mail.body).to include 'para acessar seu perfil e continuar interagindo.'
     end
 
@@ -62,7 +62,7 @@ RSpec.describe LikesMailer, type: :mailer do
       expect(mail.body).to include "A publicação mais curtida foi <a href=\"#{post_url(post)}\">#{post.title}</a>"
       expect(mail.body).not_to include "O seu comentário mais curtido foi #{comment.message} na publicação "
       expect(mail.body).not_to include "<a href=\"#{post_url(comment.post)}\">#{comment.post.title}</a>"
-      expect(mail.body).to have_link 'Clique aqui', href: profile_url(user.profile)
+      expect(mail.body).to have_link 'Clique aqui', href: profile_url(user.profile.slug)
       expect(mail.body).to include 'para acessar seu perfil e continuar interagindo.'
     end
 
@@ -81,7 +81,7 @@ RSpec.describe LikesMailer, type: :mailer do
       expect(mail.body).not_to include "A publicação mais curtida foi <a href=\"#{post_url(post)}\">#{post.title}</a>"
       expect(mail.body).to include "O seu comentário mais curtido foi #{comment.message} na publicação "
       expect(mail.body).to include "<a href=\"#{post_url(comment.post)}\">#{comment.post.title}</a>"
-      expect(mail.body).to have_link 'Clique aqui', href: profile_url(user.profile)
+      expect(mail.body).to have_link 'Clique aqui', href: profile_url(user.profile.slug)
       expect(mail.body).to include 'para acessar seu perfil e continuar interagindo.'
     end
   end


### PR DESCRIPTION
Resolve #247 

Durante a apresentação teste, percebemos que após fixar uma publicação na própria timeline, os botões de fixar/desafixar sumiam da página de perfil, sendo necessário sair dela e voltar para o botão reaparecer.

Isso estava acontecendo porque ao fixar/desafixar, o usuário era redirecionado para a própria página mas sem o friendly-id, e por conta disso o botão não era renderizado - sendo necessário sair e voltar para carregar a página com o friendly-id.

Varremos a aplicação para procurar todos redirects que não haviam sido alterados para usar o friendly-id, e adicionamos o slug em cada um deles para corrigir esse bug (e outros eventuais que poderiam existir e não percebemos).